### PR TITLE
Set ABI 14 for pypi builds

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,7 @@ jobs:
       PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}
     with:
       generate: true
+      abi-version: 14
 
   # Maybe in the future:
   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-robot
-        VERSION "1.0.0"
+        VERSION "1.1.1"
         DESCRIPTION "Tree-sitter parser for Robot Framework files"
         HOMEPAGE_URL "https://github.com/hubro/tree-sitter-robot"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-robot"
 description = "Tree-sitter parser for Robot Framework files"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["Tomas Sandven"]
 license = "ISC"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 LANGUAGE_NAME := tree-sitter-robot
 HOMEPAGE_URL := https://github.com/hubro/tree-sitter-robot
-VERSION := 1.0.0
+VERSION := 1.1.1
 
 # repository
 SRC_DIR := src

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-robot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tree-sitter parser for Robot Framework files",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-robot"
 description = "Tree-sitter parser for Robot Framework files"
-version = "1.0.0"
+version = "1.1.1"
 keywords = ["incremental", "parsing", "tree-sitter", "robot"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -17,7 +17,7 @@
     }
   ],
   "metadata": {
-    "version": "1.0.0",
+    "version": "1.1.1",
     "license": "ISC",
     "description": "Tree-sitter parser for Robot Framework files",
     "authors": [


### PR DESCRIPTION
On publish, the pypi workflow currently regenerates our parser for ABI 15 because that's the default from the [central workflow](https://github.com/tree-sitter/workflows/blob/ec44bc4f4667a458dd397ed9864f1b560e8fdca2/.github/workflows/package-pypi.yml#L24).

In Python, one needs [py-tree-sitter](https://github.com/tree-sitter/py-tree-sitter) to load the robot language. Since py-tree-sitter folks have not yet finished ABI 15 migration (tree-sitter/py-tree-sitter#333), there's currently no way to load our binding. Using the lattest py-tree-sitter 0.24 would fail with "ValueError: Incompatible Language version 15. Must be between 13 and 14".

Therefore to make tree-sitter-robot available for users, we enforce ABI 14 on regeneration for upload.

Also prepare package configs for upcoming tag version.

PS: Some of the central language bindings have basically the same problem. However, since they have published former pypi releases with lower ABI versions, there's something users can fallback to. We don't have previous releases, so no fallback is available.