### PR TITLE
Add support for curly braces in text chunks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -520,7 +520,7 @@ module.exports = grammar({
       token(
         seq(
           choice(
-            /[^\s$@&{#]/, // Can't start with a #, since that would be a comment
+            /[^\s$@&#]/, // Can't start with a #, since that would be a comment
             /[$@&][^{]/,
             /[^$@&]\{/,
           ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2365,7 +2365,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[^\\s$@&{#]"
+                "value": "[^\\s$@&#]"
               },
               {
                 "type": "PATTERN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -1652,7 +1652,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         '$', 125,
         '&', 121,
         '@', 123,
-        '{', 124,
         0x0b, 14,
         '\f', 14,
       );
@@ -1696,7 +1695,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ' ', 368,
         '#', 543,
         '$', 125,
-        '{', 124,
         '&', 325,
         '@', 325,
         0x0b, 14,
@@ -1711,8 +1709,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '$') ADVANCE(125);
       if (lookahead == '&' ||
           lookahead == '@') ADVANCE(325);
-      if (('\n' <= lookahead && lookahead <= '\r') ||
-          lookahead == '{') ADVANCE(124);
+      if (('\n' <= lookahead && lookahead <= '\r')) ADVANCE(124);
       if (lookahead != 0) ADVANCE(450);
       END_STATE();
     case 9:
@@ -3168,7 +3165,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ' ', 552,
         '#', 543,
         '*', 440,
-        '{', 124,
         0x0b, 14,
         '\f', 14,
         '$', 325,
@@ -3217,7 +3213,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         '\r', 14,
         '#', 543,
         '*', 440,
-        '{', 124,
         '\t', 554,
         ' ', 554,
         0x0b, 14,

--- a/test/corpus/settings-section.txt
+++ b/test/corpus/settings-section.txt
@@ -182,3 +182,39 @@ Documentation     This is some documentation text
             (ellipses)
             (argument
               (text_chunk))))))))
+
+================================================================================
+Settings with curly braces
+================================================================================
+
+*** Settings ***
+
+Documentation     {"title": "Test Suite", "version": "1.0"}
+Metadata          json_data    {"key": "value", "nested": {"a": 1}}
+Library           MyLibrary    config={"debug": true, "timeout": 30}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (settings_section
+      (section_header)
+      (setting_statement
+        (setting_name)
+        (arguments
+          (argument
+            (text_chunk))))
+      (setting_statement
+        (setting_name)
+        (arguments
+          (argument
+            (text_chunk))
+          (argument
+            (text_chunk))))
+      (setting_statement
+        (setting_name)
+        (arguments
+          (argument
+            (text_chunk))
+          (argument
+            (text_chunk)))))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -306,3 +306,63 @@ Test Keyword
                 (scalar_variable
                   (variable_name))
                 (name_chunk)))))))))
+
+================================================================================
+Arguments with curly braces
+================================================================================
+
+*** Keywords ***
+
+Test Keyword
+  Log JSON    {"key": "value"}
+  Log Nested JSON    {"outer": {"inner": 1}}
+  Log Multiple Args    {item1}    {item2}    {item3}
+  Log Mixed Args    ${VAR}    {"json": "value"}    text{with}braces
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (keywords_section
+      (section_header)
+      (keyword_definition
+        (name
+          (name_chunk))
+        (body
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (text_chunk)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (text_chunk)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (text_chunk))
+                (argument
+                  (text_chunk))
+                (argument
+                  (text_chunk)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (scalar_variable
+                    (variable_name)))
+                (argument
+                  (text_chunk))
+                (argument
+                  (text_chunk))))))))))

--- a/test/corpus/test-cases-section.txt
+++ b/test/corpus/test-cases-section.txt
@@ -183,3 +183,43 @@ Test That Something Works
               (arguments
                 (argument
                   (text_chunk))))))))))
+
+================================================================================
+Test cases with curly braces in arguments
+================================================================================
+
+*** Test Cases ***
+
+Test With JSON Arguments
+    [Documentation]   {"type": "integration", "level": "smoke"}
+    [Tags]            {tag1}    {tag2}
+    Log Message    {"event": "test", "status": "pass"}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (test_cases_section
+      (section_header)
+      (test_case_definition
+        (name)
+        (body
+          (test_case_setting
+            (test_case_setting_name)
+            (arguments
+              (argument
+                (text_chunk))))
+          (test_case_setting
+            (test_case_setting_name)
+            (arguments
+              (argument
+                (text_chunk))
+              (argument
+                (text_chunk))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (text_chunk))))))))))

--- a/test/corpus/variables-section.txt
+++ b/test/corpus/variables-section.txt
@@ -153,3 +153,49 @@ ${SCALAR} =    I'm a scalar variable
             (text_chunk))
           (argument
             (text_chunk)))))))
+
+================================================================================
+Variable values with curly braces
+================================================================================
+
+*** Variables ***
+
+${JSON} =    {"key": "value"}
+${NESTED} =    {"outer": {"inner": 1}}
+@{LIST} =    {item1}    {item2}
+&{DICT} =    key={"a": 1}    key2={"b": 2}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (variables_section
+      (section_header)
+      (variable_definition
+        (scalar_variable
+          (variable_name))
+        (arguments
+          (argument
+            (text_chunk))))
+      (variable_definition
+        (scalar_variable
+          (variable_name))
+        (arguments
+          (argument
+            (text_chunk))))
+      (variable_definition
+        (list_variable
+          (variable_name))
+        (arguments
+          (argument
+            (text_chunk))
+          (argument
+            (text_chunk))))
+      (variable_definition
+        (dictionary_variable
+          (variable_name))
+        (arguments
+          (argument
+            (text_chunk))
+          (argument
+            (text_chunk)))))))


### PR DESCRIPTION
For some reason, `text_chunk` was not allowed to have `{` inside it, but it's "legal" in Robot Framework, quite often used with literal JSON as a keyword argument (but can be used elsewhere).