### PR TITLE
chore(rel): bump to 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(tree-sitter-robot
-        VERSION "1.4.0"
+        VERSION "1.5.0"
         DESCRIPTION "Tree-sitter parser for Robot Framework files"
         HOMEPAGE_URL "https://github.com/hubro/tree-sitter-robot"
         LANGUAGES C)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-robot"
 description = "Tree-sitter parser for Robot Framework files"
-version = "1.4.0"
+version = "1.5.0"
 authors = ["Tomas Sandven"]
 license = "ISC"
 readme = "README.md"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ endif
 
 LANGUAGE_NAME := tree-sitter-robot
 HOMEPAGE_URL := https://github.com/hubro/tree-sitter-robot
-VERSION := 1.4.0
+VERSION := 1.5.0
 
 # repository
 SRC_DIR := src

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-robot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-robot",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-robot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Tree-sitter parser for Robot Framework files",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-robot"
 description = "Tree-sitter parser for Robot Framework files"
-version = "1.4.0"
+version = "1.5.0"
 keywords = ["incremental", "parsing", "tree-sitter", "robot"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/src/parser.c
+++ b/src/parser.c
@@ -12191,7 +12191,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_robot(void) {
     .max_reserved_word_set_size = 0,
     .metadata = {
       .major_version = 1,
-      .minor_version = 4,
+      .minor_version = 5,
       .patch_version = 0,
     },
   };

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -17,7 +17,7 @@
     }
   ],
   "metadata": {
-    "version": "1.4.0",
+    "version": "1.5.0",
     "license": "ISC",
     "description": "Tree-sitter parser for Robot Framework files",
     "authors": [


### PR DESCRIPTION
This PR updates the project version to `1.5.0`.

The last tag was about a month ago; if possible, please tag `v1.5.0` after merging so the new release is published.
If you’d rather not bump right now I completely understand - feel free to close or reject this PR.

Thanks!