### PR TITLE
Add support for subscriptable scalar variables

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -509,22 +509,22 @@ module.exports = grammar({
       ),
 
     scalar_variable: ($) =>
-    seq(
-      "${",
-      optional(" "),
-      $.variable_name,
-      optional(
-        repeat(
-          seq(
-            "[",
-            choice($.variable_key, $.scalar_variable),
-            "]"
+      seq(
+        "${",
+        optional(" "),
+        $.variable_name,
+        optional(
+          repeat(
+            seq(
+              "[",
+              choice($.variable_key, $.scalar_variable),
+              "]"
+            )
           )
-        )
+        ),
+        optional(" "),
+        "}"
       ),
-      optional(" "),
-      "}"
-    ),
 
     list_variable: ($) =>
       seq("@{", optional(" "), $.variable_name, optional(" "), "}"),

--- a/grammar.js
+++ b/grammar.js
@@ -509,7 +509,22 @@ module.exports = grammar({
       ),
 
     scalar_variable: ($) =>
-      seq("${", optional(" "), $.variable_name, optional(" "), "}"),
+    seq(
+      "${",
+      optional(" "),
+      $.variable_name,
+      optional(
+        repeat(
+          seq(
+            "[",
+            choice($.variable_key, $.scalar_variable),
+            "]"
+          )
+        )
+      ),
+      optional(" "),
+      "}"
+    ),
 
     list_variable: ($) =>
       seq("@{", optional(" "), $.variable_name, optional(" "), "}"),
@@ -526,7 +541,9 @@ module.exports = grammar({
         ),
       ),
 
-    variable_name: ($) => /[^{}]+/,
+    variable_name: ($) => /[^{}\[\]]+/,
+
+    variable_key: ($) => /[^\[\]}$@&]+/,
 
     text_chunk: ($) => $._text_chunk,
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2350,6 +2350,43 @@
           "type": "CHOICE",
           "members": [
             {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "["
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "variable_key"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scalar_variable"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "]"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
               "type": "STRING",
               "value": " "
             },
@@ -2486,7 +2523,11 @@
     },
     "variable_name": {
       "type": "PATTERN",
-      "value": "[^{}]+"
+      "value": "[^{}\\[\\]]+"
+    },
+    "variable_key": {
+      "type": "PATTERN",
+      "value": "[^\\[\\]}$@&]+"
     },
     "text_chunk": {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -677,9 +677,17 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "scalar_variable",
+          "named": true
+        },
+        {
+          "type": "variable_key",
+          "named": true
+        },
         {
           "type": "variable_name",
           "named": true
@@ -1177,6 +1185,10 @@
   },
   {
     "type": "section_header",
+    "named": true
+  },
+  {
+    "type": "variable_key",
     "named": true
   },
   {

--- a/src/parser.c
+++ b/src/parser.c
@@ -15,11 +15,11 @@
 #endif
 
 #define LANGUAGE_VERSION 15
-#define STATE_COUNT 448
+#define STATE_COUNT 472
 #define LARGE_STATE_COUNT 2
-#define SYMBOL_COUNT 142
+#define SYMBOL_COUNT 144
 #define ALIAS_COUNT 3
-#define TOKEN_COUNT 71
+#define TOKEN_COUNT 72
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 7
 #define MAX_ALIAS_SEQUENCE_LENGTH 9
@@ -93,85 +93,87 @@ enum ts_symbol_identifiers {
   aux_sym_inline_python_expression_token1 = 63,
   anon_sym_RBRACE_RBRACE = 64,
   sym_variable_name = 65,
-  sym__text_chunk = 66,
-  sym_comment = 67,
-  sym__separator = 68,
-  sym__line_break = 69,
-  aux_sym__empty_line_token1 = 70,
-  sym_source_file = 71,
-  sym_section = 72,
-  sym_comments_section = 73,
-  sym_settings_section = 74,
-  sym_setting_statement = 75,
-  sym_setting_name = 76,
-  sym_variables_section = 77,
-  sym_variable_definition = 78,
-  sym_keywords_section = 79,
-  sym_keyword_definition = 80,
-  sym_keyword_name = 81,
-  sym_name_chunk = 82,
-  sym_keyword_definition_body = 83,
-  sym_keyword_setting = 84,
-  sym_keyword_setting_name = 85,
-  sym_test_cases_section = 86,
-  sym_test_case_definition = 87,
-  sym_test_case_definition_body = 88,
-  sym_test_case_setting = 89,
-  sym_test_case_setting_name = 90,
-  sym_statement = 91,
-  sym_return_statement = 92,
-  sym_variable_assignment = 93,
-  sym_keyword_invocation = 94,
-  sym_keyword = 95,
-  sym_if_statement = 96,
-  sym_elseif_statement = 97,
-  sym_else_statement = 98,
-  sym_inline_if_statement = 99,
-  sym_block = 100,
-  sym_inline_elseif_statement = 101,
-  sym_inline_else_statement = 102,
-  sym_inline_statement = 103,
-  sym_try_statement = 104,
-  sym_except_statement = 105,
-  sym_finally_statement = 106,
-  sym_while_statement = 107,
-  sym_for_statement = 108,
-  sym__for_in = 109,
-  sym__for_in_range = 110,
-  sym__for_in_enumerate = 111,
-  sym__for_in_zip = 112,
-  sym_arguments = 113,
-  sym_arguments_without_continuation = 114,
-  sym_continuation = 115,
-  sym_argument = 116,
-  sym_scalar_variable = 117,
-  sym_list_variable = 118,
-  sym_dictionary_variable = 119,
-  sym_inline_python_expression = 120,
-  sym_text_chunk = 121,
-  sym__indentation = 122,
-  sym__empty_line = 123,
-  aux_sym_source_file_repeat1 = 124,
-  aux_sym_source_file_repeat2 = 125,
-  aux_sym_settings_section_repeat1 = 126,
-  aux_sym_variables_section_repeat1 = 127,
-  aux_sym_keywords_section_repeat1 = 128,
-  aux_sym_keyword_name_repeat1 = 129,
-  aux_sym_keyword_definition_body_repeat1 = 130,
-  aux_sym_test_cases_section_repeat1 = 131,
-  aux_sym_test_case_definition_body_repeat1 = 132,
-  aux_sym_if_statement_repeat1 = 133,
-  aux_sym_inline_if_statement_repeat1 = 134,
-  aux_sym_block_repeat1 = 135,
-  aux_sym_try_statement_repeat1 = 136,
-  aux_sym_for_statement_repeat1 = 137,
-  aux_sym_arguments_repeat1 = 138,
-  aux_sym_arguments_repeat2 = 139,
-  aux_sym_argument_repeat1 = 140,
-  aux_sym_inline_python_expression_repeat1 = 141,
-  alias_sym_python_expression = 142,
-  alias_sym_return_value = 143,
-  alias_sym_variable_list = 144,
+  sym_variable_key = 66,
+  sym__text_chunk = 67,
+  sym_comment = 68,
+  sym__separator = 69,
+  sym__line_break = 70,
+  aux_sym__empty_line_token1 = 71,
+  sym_source_file = 72,
+  sym_section = 73,
+  sym_comments_section = 74,
+  sym_settings_section = 75,
+  sym_setting_statement = 76,
+  sym_setting_name = 77,
+  sym_variables_section = 78,
+  sym_variable_definition = 79,
+  sym_keywords_section = 80,
+  sym_keyword_definition = 81,
+  sym_keyword_name = 82,
+  sym_name_chunk = 83,
+  sym_keyword_definition_body = 84,
+  sym_keyword_setting = 85,
+  sym_keyword_setting_name = 86,
+  sym_test_cases_section = 87,
+  sym_test_case_definition = 88,
+  sym_test_case_definition_body = 89,
+  sym_test_case_setting = 90,
+  sym_test_case_setting_name = 91,
+  sym_statement = 92,
+  sym_return_statement = 93,
+  sym_variable_assignment = 94,
+  sym_keyword_invocation = 95,
+  sym_keyword = 96,
+  sym_if_statement = 97,
+  sym_elseif_statement = 98,
+  sym_else_statement = 99,
+  sym_inline_if_statement = 100,
+  sym_block = 101,
+  sym_inline_elseif_statement = 102,
+  sym_inline_else_statement = 103,
+  sym_inline_statement = 104,
+  sym_try_statement = 105,
+  sym_except_statement = 106,
+  sym_finally_statement = 107,
+  sym_while_statement = 108,
+  sym_for_statement = 109,
+  sym__for_in = 110,
+  sym__for_in_range = 111,
+  sym__for_in_enumerate = 112,
+  sym__for_in_zip = 113,
+  sym_arguments = 114,
+  sym_arguments_without_continuation = 115,
+  sym_continuation = 116,
+  sym_argument = 117,
+  sym_scalar_variable = 118,
+  sym_list_variable = 119,
+  sym_dictionary_variable = 120,
+  sym_inline_python_expression = 121,
+  sym_text_chunk = 122,
+  sym__indentation = 123,
+  sym__empty_line = 124,
+  aux_sym_source_file_repeat1 = 125,
+  aux_sym_source_file_repeat2 = 126,
+  aux_sym_settings_section_repeat1 = 127,
+  aux_sym_variables_section_repeat1 = 128,
+  aux_sym_keywords_section_repeat1 = 129,
+  aux_sym_keyword_name_repeat1 = 130,
+  aux_sym_keyword_definition_body_repeat1 = 131,
+  aux_sym_test_cases_section_repeat1 = 132,
+  aux_sym_test_case_definition_body_repeat1 = 133,
+  aux_sym_if_statement_repeat1 = 134,
+  aux_sym_inline_if_statement_repeat1 = 135,
+  aux_sym_block_repeat1 = 136,
+  aux_sym_try_statement_repeat1 = 137,
+  aux_sym_for_statement_repeat1 = 138,
+  aux_sym_arguments_repeat1 = 139,
+  aux_sym_arguments_repeat2 = 140,
+  aux_sym_argument_repeat1 = 141,
+  aux_sym_scalar_variable_repeat1 = 142,
+  aux_sym_inline_python_expression_repeat1 = 143,
+  alias_sym_python_expression = 144,
+  alias_sym_return_value = 145,
+  alias_sym_variable_list = 146,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -241,6 +243,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_inline_python_expression_token1] = "inline_python_expression_token1",
   [anon_sym_RBRACE_RBRACE] = "}}",
   [sym_variable_name] = "variable_name",
+  [sym_variable_key] = "variable_key",
   [sym__text_chunk] = "_text_chunk",
   [sym_comment] = "comment",
   [sym__separator] = "_separator",
@@ -316,6 +319,7 @@ static const char * const ts_symbol_names[] = {
   [aux_sym_arguments_repeat1] = "arguments_repeat1",
   [aux_sym_arguments_repeat2] = "arguments_repeat2",
   [aux_sym_argument_repeat1] = "argument_repeat1",
+  [aux_sym_scalar_variable_repeat1] = "scalar_variable_repeat1",
   [aux_sym_inline_python_expression_repeat1] = "inline_python_expression_repeat1",
   [alias_sym_python_expression] = "python_expression",
   [alias_sym_return_value] = "return_value",
@@ -389,6 +393,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_inline_python_expression_token1] = aux_sym_inline_python_expression_token1,
   [anon_sym_RBRACE_RBRACE] = anon_sym_RBRACE_RBRACE,
   [sym_variable_name] = sym_variable_name,
+  [sym_variable_key] = sym_variable_key,
   [sym__text_chunk] = sym__text_chunk,
   [sym_comment] = sym_comment,
   [sym__separator] = sym__separator,
@@ -464,6 +469,7 @@ static const TSSymbol ts_symbol_map[] = {
   [aux_sym_arguments_repeat1] = aux_sym_arguments_repeat1,
   [aux_sym_arguments_repeat2] = aux_sym_arguments_repeat2,
   [aux_sym_argument_repeat1] = aux_sym_argument_repeat1,
+  [aux_sym_scalar_variable_repeat1] = aux_sym_scalar_variable_repeat1,
   [aux_sym_inline_python_expression_repeat1] = aux_sym_inline_python_expression_repeat1,
   [alias_sym_python_expression] = alias_sym_python_expression,
   [alias_sym_return_value] = alias_sym_return_value,
@@ -732,6 +738,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [sym_variable_name] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_variable_key] = {
     .visible = true,
     .named = true,
   },
@@ -1035,6 +1045,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = false,
     .named = false,
   },
+  [aux_sym_scalar_variable_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
   [aux_sym_inline_python_expression_repeat1] = {
     .visible = false,
     .named = false,
@@ -1226,7 +1240,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [39] = 39,
   [40] = 40,
   [41] = 41,
-  [42] = 7,
+  [42] = 42,
   [43] = 43,
   [44] = 44,
   [45] = 45,
@@ -1241,24 +1255,24 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [54] = 54,
   [55] = 55,
   [56] = 56,
-  [57] = 57,
-  [58] = 43,
+  [57] = 7,
+  [58] = 45,
   [59] = 59,
   [60] = 60,
   [61] = 61,
   [62] = 62,
   [63] = 63,
   [64] = 64,
-  [65] = 7,
-  [66] = 66,
+  [65] = 65,
+  [66] = 7,
   [67] = 67,
   [68] = 7,
-  [69] = 63,
-  [70] = 67,
-  [71] = 60,
-  [72] = 60,
-  [73] = 63,
-  [74] = 67,
+  [69] = 60,
+  [70] = 65,
+  [71] = 63,
+  [72] = 63,
+  [73] = 60,
+  [74] = 65,
   [75] = 75,
   [76] = 76,
   [77] = 77,
@@ -1268,8 +1282,8 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [81] = 81,
   [82] = 82,
   [83] = 83,
-  [84] = 75,
-  [85] = 85,
+  [84] = 84,
+  [85] = 79,
   [86] = 86,
   [87] = 87,
   [88] = 88,
@@ -1303,118 +1317,118 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [116] = 116,
   [117] = 117,
   [118] = 118,
-  [119] = 119,
+  [119] = 104,
   [120] = 120,
   [121] = 121,
   [122] = 122,
   [123] = 123,
-  [124] = 110,
+  [124] = 124,
   [125] = 125,
   [126] = 126,
   [127] = 127,
   [128] = 128,
   [129] = 129,
-  [130] = 129,
+  [130] = 130,
   [131] = 131,
-  [132] = 132,
+  [132] = 123,
   [133] = 133,
   [134] = 134,
   [135] = 135,
-  [136] = 133,
+  [136] = 136,
   [137] = 137,
-  [138] = 133,
-  [139] = 139,
+  [138] = 112,
+  [139] = 104,
   [140] = 140,
-  [141] = 126,
-  [142] = 142,
-  [143] = 143,
+  [141] = 115,
+  [142] = 125,
+  [143] = 133,
   [144] = 144,
   [145] = 145,
-  [146] = 146,
-  [147] = 131,
-  [148] = 105,
-  [149] = 107,
-  [150] = 115,
-  [151] = 139,
-  [152] = 118,
-  [153] = 119,
-  [154] = 131,
-  [155] = 121,
-  [156] = 122,
-  [157] = 123,
-  [158] = 105,
-  [159] = 107,
-  [160] = 126,
-  [161] = 127,
-  [162] = 128,
-  [163] = 115,
-  [164] = 118,
-  [165] = 119,
-  [166] = 122,
-  [167] = 123,
-  [168] = 127,
-  [169] = 128,
-  [170] = 139,
-  [171] = 121,
-  [172] = 146,
-  [173] = 173,
-  [174] = 174,
-  [175] = 175,
-  [176] = 121,
-  [177] = 122,
-  [178] = 123,
-  [179] = 179,
-  [180] = 139,
+  [146] = 129,
+  [147] = 137,
+  [148] = 115,
+  [149] = 126,
+  [150] = 150,
+  [151] = 124,
+  [152] = 134,
+  [153] = 126,
+  [154] = 127,
+  [155] = 128,
+  [156] = 156,
+  [157] = 156,
+  [158] = 130,
+  [159] = 131,
+  [160] = 125,
+  [161] = 133,
+  [162] = 134,
+  [163] = 135,
+  [164] = 136,
+  [165] = 137,
+  [166] = 124,
+  [167] = 127,
+  [168] = 128,
+  [169] = 130,
+  [170] = 131,
+  [171] = 135,
+  [172] = 136,
+  [173] = 126,
+  [174] = 129,
+  [175] = 134,
+  [176] = 137,
+  [177] = 177,
+  [178] = 178,
+  [179] = 129,
+  [180] = 180,
   [181] = 181,
-  [182] = 118,
+  [182] = 182,
   [183] = 183,
-  [184] = 119,
-  [185] = 185,
-  [186] = 128,
-  [187] = 187,
+  [184] = 128,
+  [185] = 181,
+  [186] = 186,
+  [187] = 130,
   [188] = 188,
   [189] = 189,
-  [190] = 126,
-  [191] = 127,
+  [190] = 190,
+  [191] = 131,
   [192] = 192,
-  [193] = 179,
-  [194] = 194,
+  [193] = 135,
+  [194] = 136,
   [195] = 195,
-  [196] = 174,
+  [196] = 196,
   [197] = 197,
-  [198] = 179,
-  [199] = 174,
-  [200] = 7,
+  [198] = 198,
+  [199] = 199,
+  [200] = 200,
   [201] = 201,
-  [202] = 202,
-  [203] = 203,
+  [202] = 199,
+  [203] = 200,
   [204] = 204,
   [205] = 205,
-  [206] = 206,
-  [207] = 207,
-  [208] = 192,
-  [209] = 209,
+  [206] = 196,
+  [207] = 180,
+  [208] = 197,
+  [209] = 181,
   [210] = 210,
-  [211] = 211,
-  [212] = 212,
-  [213] = 213,
-  [214] = 214,
-  [215] = 215,
-  [216] = 216,
-  [217] = 206,
-  [218] = 218,
-  [219] = 211,
-  [220] = 203,
-  [221] = 221,
-  [222] = 222,
-  [223] = 194,
-  [224] = 195,
-  [225] = 209,
+  [211] = 199,
+  [212] = 200,
+  [213] = 196,
+  [214] = 180,
+  [215] = 197,
+  [216] = 181,
+  [217] = 199,
+  [218] = 196,
+  [219] = 180,
+  [220] = 181,
+  [221] = 199,
+  [222] = 196,
+  [223] = 180,
+  [224] = 127,
+  [225] = 225,
   [226] = 226,
-  [227] = 213,
+  [227] = 227,
   [228] = 228,
   [229] = 229,
-  [230] = 230,
+  [230] = 201,
   [231] = 231,
   [232] = 232,
   [233] = 233,
@@ -1423,21 +1437,21 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [236] = 236,
   [237] = 237,
   [238] = 238,
-  [239] = 239,
+  [239] = 228,
   [240] = 240,
-  [241] = 241,
+  [241] = 204,
   [242] = 242,
   [243] = 243,
   [244] = 244,
-  [245] = 245,
-  [246] = 246,
-  [247] = 247,
+  [245] = 232,
+  [246] = 205,
+  [247] = 226,
   [248] = 248,
-  [249] = 249,
+  [249] = 225,
   [250] = 250,
   [251] = 251,
-  [252] = 252,
-  [253] = 253,
+  [252] = 7,
+  [253] = 233,
   [254] = 254,
   [255] = 255,
   [256] = 256,
@@ -1445,7 +1459,7 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [258] = 258,
   [259] = 259,
   [260] = 260,
-  [261] = 261,
+  [261] = 124,
   [262] = 262,
   [263] = 263,
   [264] = 264,
@@ -1455,65 +1469,65 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [268] = 268,
   [269] = 269,
   [270] = 270,
-  [271] = 115,
+  [271] = 271,
   [272] = 272,
   [273] = 273,
   [274] = 274,
   [275] = 275,
-  [276] = 258,
-  [277] = 264,
-  [278] = 265,
+  [276] = 276,
+  [277] = 277,
+  [278] = 278,
   [279] = 279,
   [280] = 280,
-  [281] = 251,
-  [282] = 256,
-  [283] = 266,
-  [284] = 258,
-  [285] = 264,
-  [286] = 265,
+  [281] = 281,
+  [282] = 282,
+  [283] = 283,
+  [284] = 284,
+  [285] = 285,
+  [286] = 286,
   [287] = 287,
-  [288] = 251,
-  [289] = 256,
-  [290] = 266,
+  [288] = 288,
+  [289] = 289,
+  [290] = 290,
   [291] = 291,
   [292] = 292,
-  [293] = 258,
-  [294] = 264,
-  [295] = 265,
-  [296] = 251,
-  [297] = 256,
-  [298] = 266,
-  [299] = 258,
-  [300] = 251,
-  [301] = 292,
-  [302] = 262,
-  [303] = 229,
-  [304] = 259,
-  [305] = 292,
-  [306] = 262,
-  [307] = 229,
-  [308] = 292,
-  [309] = 262,
-  [310] = 229,
-  [311] = 292,
-  [312] = 312,
-  [313] = 313,
-  [314] = 314,
-  [315] = 315,
+  [293] = 293,
+  [294] = 294,
+  [295] = 280,
+  [296] = 296,
+  [297] = 297,
+  [298] = 298,
+  [299] = 294,
+  [300] = 300,
+  [301] = 301,
+  [302] = 302,
+  [303] = 303,
+  [304] = 301,
+  [305] = 300,
+  [306] = 306,
+  [307] = 294,
+  [308] = 300,
+  [309] = 303,
+  [310] = 301,
+  [311] = 311,
+  [312] = 294,
+  [313] = 300,
+  [314] = 303,
+  [315] = 301,
   [316] = 316,
   [317] = 317,
-  [318] = 318,
-  [319] = 319,
-  [320] = 320,
-  [321] = 321,
+  [318] = 280,
+  [319] = 281,
+  [320] = 284,
+  [321] = 290,
   [322] = 322,
-  [323] = 323,
-  [324] = 324,
-  [325] = 325,
-  [326] = 313,
-  [327] = 327,
-  [328] = 328,
-  [329] = 329,
+  [323] = 280,
+  [324] = 281,
+  [325] = 284,
+  [326] = 280,
+  [327] = 281,
+  [328] = 284,
+  [329] = 303,
   [330] = 330,
   [331] = 331,
   [332] = 332,
@@ -1538,100 +1552,129 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
   [351] = 351,
   [352] = 352,
   [353] = 353,
-  [354] = 354,
-  [355] = 139,
+  [354] = 330,
+  [355] = 355,
   [356] = 356,
   [357] = 357,
-  [358] = 121,
+  [358] = 358,
   [359] = 359,
   [360] = 360,
-  [361] = 126,
+  [361] = 361,
   [362] = 362,
   [363] = 363,
   [364] = 364,
-  [365] = 365,
+  [365] = 126,
   [366] = 366,
   [367] = 367,
-  [368] = 368,
+  [368] = 129,
   [369] = 369,
   [370] = 370,
-  [371] = 371,
+  [371] = 134,
   [372] = 372,
   [373] = 373,
-  [374] = 374,
-  [375] = 320,
+  [374] = 137,
+  [375] = 375,
   [376] = 376,
   [377] = 377,
   [378] = 378,
-  [379] = 314,
+  [379] = 379,
   [380] = 380,
-  [381] = 332,
+  [381] = 381,
   [382] = 382,
-  [383] = 346,
+  [383] = 383,
   [384] = 384,
   [385] = 385,
   [386] = 386,
   [387] = 387,
   [388] = 388,
   [389] = 389,
-  [390] = 317,
-  [391] = 368,
+  [390] = 390,
+  [391] = 349,
   [392] = 392,
   [393] = 393,
-  [394] = 394,
-  [395] = 368,
-  [396] = 396,
-  [397] = 314,
+  [394] = 378,
+  [395] = 395,
+  [396] = 392,
+  [397] = 397,
   [398] = 398,
-  [399] = 332,
+  [399] = 399,
   [400] = 400,
-  [401] = 346,
-  [402] = 402,
+  [401] = 332,
+  [402] = 338,
   [403] = 403,
-  [404] = 386,
-  [405] = 387,
-  [406] = 388,
-  [407] = 368,
+  [404] = 404,
+  [405] = 385,
+  [406] = 406,
+  [407] = 407,
   [408] = 408,
   [409] = 409,
-  [410] = 410,
+  [410] = 403,
   [411] = 411,
-  [412] = 314,
+  [412] = 349,
   [413] = 413,
-  [414] = 332,
-  [415] = 415,
-  [416] = 346,
-  [417] = 386,
-  [418] = 387,
-  [419] = 388,
-  [420] = 368,
+  [414] = 414,
+  [415] = 378,
+  [416] = 416,
+  [417] = 392,
+  [418] = 418,
+  [419] = 419,
+  [420] = 399,
   [421] = 421,
-  [422] = 422,
-  [423] = 314,
-  [424] = 386,
-  [425] = 425,
+  [422] = 332,
+  [423] = 338,
+  [424] = 403,
+  [425] = 380,
   [426] = 426,
   [427] = 427,
-  [428] = 318,
+  [428] = 428,
   [429] = 429,
-  [430] = 338,
-  [431] = 386,
-  [432] = 325,
-  [433] = 433,
-  [434] = 387,
-  [435] = 435,
-  [436] = 318,
-  [437] = 313,
-  [438] = 338,
-  [439] = 439,
-  [440] = 440,
-  [441] = 441,
-  [442] = 318,
-  [443] = 313,
-  [444] = 338,
-  [445] = 388,
-  [446] = 318,
+  [430] = 349,
+  [431] = 431,
+  [432] = 380,
+  [433] = 378,
+  [434] = 434,
+  [435] = 392,
+  [436] = 399,
+  [437] = 437,
+  [438] = 332,
+  [439] = 338,
+  [440] = 403,
+  [441] = 380,
+  [442] = 442,
+  [443] = 443,
+  [444] = 349,
+  [445] = 445,
+  [446] = 399,
   [447] = 447,
+  [448] = 403,
+  [449] = 449,
+  [450] = 450,
+  [451] = 451,
+  [452] = 345,
+  [453] = 361,
+  [454] = 383,
+  [455] = 455,
+  [456] = 456,
+  [457] = 457,
+  [458] = 458,
+  [459] = 399,
+  [460] = 345,
+  [461] = 361,
+  [462] = 383,
+  [463] = 463,
+  [464] = 464,
+  [465] = 387,
+  [466] = 345,
+  [467] = 361,
+  [468] = 383,
+  [469] = 469,
+  [470] = 345,
+  [471] = 380,
+};
+
+static const TSCharacterRange sym_variable_key_character_set_1[] = {
+  {0, '#'}, {'%', '%'}, {'\'', '?'}, {'A', 'Z'}, {'\\', '\\'}, {'^', '|'}, {'~', 0x17e}, {0x180, 0x2129},
+  {0x212b, 0x10ffff},
 };
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -1668,7 +1711,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ADVANCE_MAP(
         '\t', 36,
         ' ', 401,
-        '#', 597,
+        '#', 600,
+        '[', 403,
         ']', 404,
         '}', 420,
         'A', 272,
@@ -1685,16 +1729,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 2:
       if (lookahead == '\t') ADVANCE(36);
-      if (lookahead == ' ') ADVANCE(601);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == ' ') ADVANCE(604);
+      if (lookahead == '#') ADVANCE(600);
       END_STATE();
     case 3:
       ADVANCE_MAP(
-        '\t', 598,
-        '\n', 602,
+        '\t', 601,
+        '\n', 605,
         '\r', 14,
         ' ', 399,
-        '#', 595,
+        '#', 598,
         '$', 132,
         '&', 128,
         '@', 130,
@@ -1703,38 +1747,40 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       );
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(484);
+          lookahead != 0x212a) ADVANCE(487);
       END_STATE();
     case 4:
       ADVANCE_MAP(
-        '\t', 599,
-        '\n', 603,
+        '\t', 602,
+        '\n', 606,
         '\r', 15,
-        ' ', 605,
-        '#', 597,
-        '.', 70,
-        'E', 101,
-        'F', 92,
+        ' ', 608,
+        '#', 600,
+        '.', 71,
+        'E', 97,
         0x0b, 15,
         '\f', 15,
       );
       END_STATE();
     case 5:
-      if (lookahead == '\t') ADVANCE(599);
-      if (lookahead == '\n') ADVANCE(603);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == ' ') ADVANCE(6);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '=') ADVANCE(393);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
+      ADVANCE_MAP(
+        '\t', 602,
+        '\n', 606,
+        '\r', 15,
+        ' ', 6,
+        '#', 600,
+        '=', 393,
+        ']', 404,
+        0x0b, 15,
+        '\f', 15,
+      );
       END_STATE();
     case 6:
       if (lookahead == '\t') ADVANCE(12);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == ' ') ADVANCE(599);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == ' ') ADVANCE(602);
+      if (lookahead == '#') ADVANCE(600);
       if (lookahead == '=') ADVANCE(394);
       if (lookahead == 0x0b ||
           lookahead == '\f') ADVANCE(15);
@@ -1742,10 +1788,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 7:
       ADVANCE_MAP(
         '\t', 11,
-        '\n', 602,
+        '\n', 605,
         '\r', 14,
         ' ', 400,
-        '#', 595,
+        '#', 598,
         '$', 132,
         '&', 354,
         '@', 354,
@@ -1754,57 +1800,59 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       );
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(484);
+          lookahead != 0x212a) ADVANCE(487);
       END_STATE();
     case 8:
-      if (lookahead == '\t') ADVANCE(600);
+      if (lookahead == '\t') ADVANCE(603);
       if (lookahead == ' ') ADVANCE(398);
-      if (lookahead == '#') ADVANCE(595);
+      if (lookahead == '#') ADVANCE(598);
       if (lookahead == '$') ADVANCE(132);
       if (lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\n' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(484);
+          lookahead != 0x212a) ADVANCE(487);
       END_STATE();
     case 9:
-      if (lookahead == '\t') ADVANCE(601);
+      if (lookahead == '\t') ADVANCE(604);
       if (lookahead == ' ') ADVANCE(2);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '.') ADVANCE(70);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '.') ADVANCE(71);
       END_STATE();
     case 10:
       if (lookahead == '\t') ADVANCE(464);
       if (lookahead == ' ') ADVANCE(402);
       if (lookahead == '#') ADVANCE(463);
       if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']' &&
           lookahead != '{' &&
           lookahead != '}' &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(465);
       END_STATE();
     case 11:
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
       if (lookahead == 0x0b ||
           lookahead == '\f') ADVANCE(15);
       END_STATE();
     case 12:
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == '#') ADVANCE(600);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
       if (lookahead == 0x0b ||
           lookahead == '\f') ADVANCE(15);
       END_STATE();
     case 13:
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
       if (lookahead == '#') ADVANCE(365);
       if (lookahead == '\t' ||
@@ -1816,14 +1864,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != 0x212a) ADVANCE(366);
       END_STATE();
     case 14:
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == '{') ADVANCE(525);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') ADVANCE(15);
       END_STATE();
     case 15:
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') ADVANCE(15);
@@ -1856,37 +1904,37 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == ' ') ADVANCE(301);
       END_STATE();
     case 21:
-      if (lookahead == ' ') ADVANCE(57);
-      if (lookahead == '*') ADVANCE(47);
+      if (lookahead == ' ') ADVANCE(58);
+      if (lookahead == '*') ADVANCE(48);
       END_STATE();
     case 22:
       if (lookahead == ' ') ADVANCE(319);
       END_STATE();
     case 23:
-      if (lookahead == ' ') ADVANCE(60);
-      if (lookahead == '*') ADVANCE(48);
+      if (lookahead == ' ') ADVANCE(61);
+      if (lookahead == '*') ADVANCE(49);
       END_STATE();
     case 24:
       if (lookahead == ' ') ADVANCE(329);
       END_STATE();
     case 25:
-      if (lookahead == ' ') ADVANCE(63);
-      if (lookahead == '*') ADVANCE(49);
+      if (lookahead == ' ') ADVANCE(64);
+      if (lookahead == '*') ADVANCE(50);
       END_STATE();
     case 26:
       if (lookahead == ' ') ADVANCE(330);
       END_STATE();
     case 27:
-      if (lookahead == ' ') ADVANCE(66);
-      if (lookahead == '*') ADVANCE(52);
-      END_STATE();
-    case 28:
-      if (lookahead == ' ') ADVANCE(68);
+      if (lookahead == ' ') ADVANCE(67);
       if (lookahead == '*') ADVANCE(53);
       END_STATE();
-    case 29:
+    case 28:
       if (lookahead == ' ') ADVANCE(69);
       if (lookahead == '*') ADVANCE(54);
+      END_STATE();
+    case 29:
+      if (lookahead == ' ') ADVANCE(70);
+      if (lookahead == '*') ADVANCE(55);
       END_STATE();
     case 30:
       ADVANCE_MAP(
@@ -2005,7 +2053,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != 0x212a) ADVANCE(422);
       END_STATE();
     case 36:
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == '#') ADVANCE(600);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(36);
       END_STATE();
@@ -2022,38 +2070,44 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != 0x212a) ADVANCE(461);
       END_STATE();
     case 38:
+      if (lookahead == '#') ADVANCE(466);
+      if (lookahead == '$') ADVANCE(126);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(467);
+      if ((!eof && set_contains(sym_variable_key_character_set_1, 9, lookahead))) ADVANCE(468);
+      END_STATE();
+    case 39:
       if (lookahead == '#') ADVANCE(463);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(464);
       if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']' &&
           lookahead != '{' &&
           lookahead != '}' &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(465);
       END_STATE();
-    case 39:
+    case 40:
       if (lookahead == '*') ADVANCE(16);
       END_STATE();
-    case 40:
+    case 41:
       if (lookahead == '*') ADVANCE(412);
       END_STATE();
-    case 41:
+    case 42:
       if (lookahead == '*') ADVANCE(360);
       END_STATE();
-    case 42:
+    case 43:
       if (lookahead == '*') ADVANCE(395);
       END_STATE();
-    case 43:
+    case 44:
       if (lookahead == '*') ADVANCE(367);
       END_STATE();
-    case 44:
+    case 45:
       if (lookahead == '*') ADVANCE(390);
       END_STATE();
-    case 45:
-      if (lookahead == '*') ADVANCE(410);
-      END_STATE();
     case 46:
-      if (lookahead == '*') ADVANCE(39);
+      if (lookahead == '*') ADVANCE(410);
       END_STATE();
     case 47:
       if (lookahead == '*') ADVANCE(40);
@@ -2065,19 +2119,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '*') ADVANCE(42);
       END_STATE();
     case 50:
-      if (lookahead == '*') ADVANCE(529);
-      if (lookahead == '{') ADVANCE(485);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+      if (lookahead == '*') ADVANCE(43);
       END_STATE();
     case 51:
-      if (lookahead == '*') ADVANCE(529);
+      if (lookahead == '*') ADVANCE(532);
+      if (lookahead == '{') ADVANCE(488);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2085,10 +2131,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 52:
-      if (lookahead == '*') ADVANCE(43);
+      if (lookahead == '*') ADVANCE(532);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 53:
       if (lookahead == '*') ADVANCE(44);
@@ -2097,19 +2151,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '*') ADVANCE(45);
       END_STATE();
     case 55:
-      if (lookahead == '*') ADVANCE(530);
-      if (lookahead == '{') ADVANCE(485);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+      if (lookahead == '*') ADVANCE(46);
       END_STATE();
     case 56:
-      if (lookahead == '*') ADVANCE(530);
+      if (lookahead == '*') ADVANCE(533);
+      if (lookahead == '{') ADVANCE(488);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2117,40 +2163,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 57:
-      if (lookahead == '*') ADVANCE(47);
+      if (lookahead == '*') ADVANCE(533);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 58:
-      if (lookahead == '*') ADVANCE(531);
-      if (lookahead == '{') ADVANCE(485);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 59:
-      if (lookahead == '*') ADVANCE(531);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 60:
       if (lookahead == '*') ADVANCE(48);
       END_STATE();
-    case 61:
-      if (lookahead == '*') ADVANCE(532);
-      if (lookahead == '{') ADVANCE(485);
+    case 59:
+      if (lookahead == '*') ADVANCE(534);
+      if (lookahead == '{') ADVANCE(488);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2158,49 +2189,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 62:
-      if (lookahead == '*') ADVANCE(532);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 63:
-      if (lookahead == '*') ADVANCE(49);
-      END_STATE();
-    case 64:
-      if (lookahead == '*') ADVANCE(533);
-      if (lookahead == '{') ADVANCE(485);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 65:
-      if (lookahead == '*') ADVANCE(533);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 66:
-      if (lookahead == '*') ADVANCE(52);
-      END_STATE();
-    case 67:
+    case 60:
       if (lookahead == '*') ADVANCE(534);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -2209,84 +2200,147 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 61:
+      if (lookahead == '*') ADVANCE(49);
+      END_STATE();
+    case 62:
+      if (lookahead == '*') ADVANCE(535);
+      if (lookahead == '{') ADVANCE(488);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 63:
+      if (lookahead == '*') ADVANCE(535);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 64:
+      if (lookahead == '*') ADVANCE(50);
+      END_STATE();
+    case 65:
+      if (lookahead == '*') ADVANCE(536);
+      if (lookahead == '{') ADVANCE(488);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 66:
+      if (lookahead == '*') ADVANCE(536);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 67:
+      if (lookahead == '*') ADVANCE(53);
       END_STATE();
     case 68:
-      if (lookahead == '*') ADVANCE(53);
+      if (lookahead == '*') ADVANCE(537);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 69:
       if (lookahead == '*') ADVANCE(54);
       END_STATE();
     case 70:
-      if (lookahead == '.') ADVANCE(71);
+      if (lookahead == '*') ADVANCE(55);
       END_STATE();
     case 71:
-      if (lookahead == '.') ADVANCE(455);
+      if (lookahead == '.') ADVANCE(72);
       END_STATE();
     case 72:
-      if (lookahead == 'A') ADVANCE(96);
+      if (lookahead == '.') ADVANCE(455);
       END_STATE();
     case 73:
-      if (lookahead == 'A') ADVANCE(99);
+      if (lookahead == 'A') ADVANCE(96);
       END_STATE();
     case 74:
-      if (lookahead == 'A') ADVANCE(120);
+      if (lookahead == 'A') ADVANCE(99);
       END_STATE();
     case 75:
-      if (lookahead == 'A') ADVANCE(105);
+      if (lookahead == 'A') ADVANCE(120);
       END_STATE();
     case 76:
-      if (lookahead == 'C') ADVANCE(80);
+      if (lookahead == 'A') ADVANCE(105);
       END_STATE();
     case 77:
-      if (lookahead == 'D') ADVANCE(440);
+      if (lookahead == 'C') ADVANCE(81);
       END_STATE();
     case 78:
-      if (lookahead == 'E') ADVANCE(72);
+      if (lookahead == 'D') ADVANCE(440);
       END_STATE();
     case 79:
-      if (lookahead == 'E') ADVANCE(443);
+      if (lookahead == 'E') ADVANCE(73);
       END_STATE();
     case 80:
-      if (lookahead == 'E') ADVANCE(111);
+      if (lookahead == 'E') ADVANCE(443);
       END_STATE();
     case 81:
-      if (lookahead == 'E') ADVANCE(447);
+      if (lookahead == 'E') ADVANCE(111);
       END_STATE();
     case 82:
-      if (lookahead == 'E') ADVANCE(453);
+      if (lookahead == 'E') ADVANCE(447);
       END_STATE();
     case 83:
-      if (lookahead == 'E') ADVANCE(450);
+      if (lookahead == 'E') ADVANCE(453);
       END_STATE();
     case 84:
-      if (lookahead == 'E') ADVANCE(451);
-      END_STATE();
-    case 85:
       if (lookahead == 'E') ADVANCE(442);
       END_STATE();
+    case 85:
+      if (lookahead == 'E') ADVANCE(450);
+      END_STATE();
     case 86:
-      if (lookahead == 'E') ADVANCE(114);
+      if (lookahead == 'E') ADVANCE(451);
       END_STATE();
     case 87:
-      if (lookahead == 'E') ADVANCE(109);
-      if (lookahead == 'R') ADVANCE(75);
-      if (lookahead == 'Z') ADVANCE(94);
+      if (lookahead == 'E') ADVANCE(114);
       END_STATE();
     case 88:
-      if (lookahead == 'F') ADVANCE(441);
+      if (lookahead == 'E') ADVANCE(109);
+      if (lookahead == 'R') ADVANCE(76);
+      if (lookahead == 'Z') ADVANCE(94);
       END_STATE();
     case 89:
-      if (lookahead == 'G') ADVANCE(83);
+      if (lookahead == 'F') ADVANCE(441);
       END_STATE();
     case 90:
-      if (lookahead == 'I') ADVANCE(100);
+      if (lookahead == 'G') ADVANCE(85);
       END_STATE();
     case 91:
-      if (lookahead == 'I') ADVANCE(88);
+      if (lookahead == 'I') ADVANCE(100);
       END_STATE();
     case 92:
-      if (lookahead == 'I') ADVANCE(107);
+      if (lookahead == 'I') ADVANCE(89);
       END_STATE();
     case 93:
       if (lookahead == 'I') ADVANCE(107);
@@ -2304,8 +2358,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 97:
       if (lookahead == 'L') ADVANCE(115);
-      if (lookahead == 'N') ADVANCE(77);
-      if (lookahead == 'X') ADVANCE(76);
+      if (lookahead == 'N') ADVANCE(78);
       END_STATE();
     case 98:
       if (lookahead == 'L') ADVANCE(125);
@@ -2314,15 +2367,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'L') ADVANCE(98);
       END_STATE();
     case 100:
-      if (lookahead == 'L') ADVANCE(81);
+      if (lookahead == 'L') ADVANCE(82);
       END_STATE();
     case 101:
       if (lookahead == 'L') ADVANCE(116);
-      if (lookahead == 'N') ADVANCE(77);
-      if (lookahead == 'X') ADVANCE(76);
+      if (lookahead == 'N') ADVANCE(78);
+      if (lookahead == 'X') ADVANCE(77);
       END_STATE();
     case 102:
-      if (lookahead == 'M') ADVANCE(86);
+      if (lookahead == 'M') ADVANCE(87);
       END_STATE();
     case 103:
       if (lookahead == 'N') ADVANCE(417);
@@ -2331,13 +2384,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'N') ADVANCE(449);
       END_STATE();
     case 105:
-      if (lookahead == 'N') ADVANCE(89);
+      if (lookahead == 'N') ADVANCE(90);
       END_STATE();
     case 106:
       if (lookahead == 'N') ADVANCE(119);
       END_STATE();
     case 107:
-      if (lookahead == 'N') ADVANCE(73);
+      if (lookahead == 'N') ADVANCE(74);
       END_STATE();
     case 108:
       if (lookahead == 'N') ADVANCE(123);
@@ -2358,13 +2411,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'R') ADVANCE(103);
       END_STATE();
     case 114:
-      if (lookahead == 'R') ADVANCE(74);
+      if (lookahead == 'R') ADVANCE(75);
       END_STATE();
     case 115:
-      if (lookahead == 'S') ADVANCE(79);
+      if (lookahead == 'S') ADVANCE(80);
       END_STATE();
     case 116:
-      if (lookahead == 'S') ADVANCE(85);
+      if (lookahead == 'S') ADVANCE(84);
       END_STATE();
     case 117:
       if (lookahead == 'T') ADVANCE(122);
@@ -2376,7 +2429,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'T') ADVANCE(95);
       END_STATE();
     case 120:
-      if (lookahead == 'T') ADVANCE(84);
+      if (lookahead == 'T') ADVANCE(86);
       END_STATE();
     case 121:
       if (lookahead == 'U') ADVANCE(102);
@@ -2385,7 +2438,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'U') ADVANCE(113);
       END_STATE();
     case 123:
-      if (lookahead == 'U') ADVANCE(82);
+      if (lookahead == 'U') ADVANCE(83);
       END_STATE();
     case 124:
       if (lookahead == 'Y') ADVANCE(444);
@@ -2403,7 +2456,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(457);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(522);
+          lookahead != 0x212a) ADVANCE(525);
       END_STATE();
     case 129:
       if (lookahead == '{') ADVANCE(456);
@@ -2412,30 +2465,30 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '{') ADVANCE(456);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(522);
+          lookahead != 0x212a) ADVANCE(525);
       END_STATE();
     case 131:
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == '{') ADVANCE(525);
       END_STATE();
     case 132:
       if (lookahead == '{') ADVANCE(419);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(522);
+          lookahead != 0x212a) ADVANCE(525);
       END_STATE();
     case 133:
       ADVANCE_MAP(
-        '{', 485,
-        'C', 556,
-        'c', 556,
-        'K', 542,
-        'k', 542,
-        'S', 543,
-        's', 543,
-        'T', 538,
-        't', 538,
-        'V', 536,
-        'v', 536,
+        '{', 488,
+        'C', 559,
+        'c', 559,
+        'K', 545,
+        'k', 545,
+        'S', 546,
+        's', 546,
+        'T', 541,
+        't', 541,
+        'V', 539,
+        'v', 539,
         '$', 355,
         '&', 355,
         '@', 355,
@@ -2444,12 +2497,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 134:
-      if (lookahead == '{') ADVANCE(485);
+      if (lookahead == '{') ADVANCE(488);
       if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(539);
+          lookahead == 'c') ADVANCE(542);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2457,10 +2510,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 135:
-      if (lookahead == '{') ADVANCE(485);
+      if (lookahead == '{') ADVANCE(488);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2468,10 +2521,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 136:
-      if (lookahead == '{') ADVANCE(576);
+      if (lookahead == '{') ADVANCE(579);
       END_STATE();
     case 137:
       if (lookahead == 'A' ||
@@ -2633,7 +2686,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 168:
       if (lookahead == 'C' ||
-          lookahead == 'c') ADVANCE(539);
+          lookahead == 'c') ADVANCE(542);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
@@ -2641,7 +2694,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 169:
       if (lookahead == 'C' ||
@@ -3403,29 +3456,29 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == ' ') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 354:
       if (lookahead != 0 &&
           lookahead != '{' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(522);
+          lookahead != 0x212a) ADVANCE(525);
       END_STATE();
     case 355:
       if (lookahead != 0 &&
           lookahead != '{' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(576);
+          lookahead != 0x212a) ADVANCE(579);
       END_STATE();
     case 356:
       if (eof) ADVANCE(359);
       ADVANCE_MAP(
-        '\t', 598,
-        '\n', 602,
+        '\t', 601,
+        '\n', 605,
         '\r', 14,
-        ' ', 604,
-        '#', 595,
-        '*', 472,
+        ' ', 607,
+        '#', 598,
+        '*', 475,
         0x0b, 14,
         '\f', 14,
         '$', 354,
@@ -3434,28 +3487,28 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       );
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(484);
+          lookahead != 0x212a) ADVANCE(487);
       END_STATE();
     case 357:
       if (eof) ADVANCE(359);
       ADVANCE_MAP(
-        '\n', 603,
+        '\n', 606,
         '\r', 15,
-        '#', 597,
+        '#', 600,
         '$', 126,
         '&', 127,
-        '*', 46,
-        '.', 70,
+        '*', 47,
+        '.', 71,
         '@', 129,
-        'E', 97,
+        'E', 101,
         'F', 93,
         'I', 104,
         '[', 403,
         ']', 404,
         'f', 252,
         '}', 420,
-        '\t', 607,
-        ' ', 607,
+        '\t', 610,
+        ' ', 610,
         'A', 272,
         'a', 272,
         'D', 180,
@@ -3483,12 +3536,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 358:
       if (eof) ADVANCE(359);
       ADVANCE_MAP(
-        '\n', 602,
+        '\n', 605,
         '\r', 14,
-        '#', 595,
-        '*', 472,
-        '\t', 606,
-        ' ', 606,
+        '#', 598,
+        '*', 475,
+        '\t', 609,
+        ' ', 609,
         0x0b, 14,
         '\f', 14,
         '$', 354,
@@ -3497,7 +3550,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       );
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(484);
+          lookahead != 0x212a) ADVANCE(487);
       END_STATE();
     case 359:
       ACCEPT_TOKEN(ts_builtin_sym_end);
@@ -3514,7 +3567,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 362:
       ACCEPT_TOKEN(aux_sym_comments_section_token1);
@@ -3525,11 +3578,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 363:
       ACCEPT_TOKEN(aux_sym_comments_section_token2);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
       if (lookahead == '#') ADVANCE(365);
       if (lookahead == '\t' ||
@@ -3542,7 +3595,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 364:
       ACCEPT_TOKEN(aux_sym_comments_section_token2);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') ADVANCE(364);
@@ -3552,7 +3605,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 365:
       ACCEPT_TOKEN(aux_sym_comments_section_token2);
-      if (lookahead == '\r') ADVANCE(597);
+      if (lookahead == '\r') ADVANCE(600);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != 0x17f &&
@@ -3578,7 +3631,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(aux_sym_settings_section_token1);
@@ -3589,7 +3642,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(aux_sym_setting_name_token1);
@@ -3663,7 +3716,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 392:
       ACCEPT_TOKEN(aux_sym_variables_section_token1);
@@ -3674,7 +3727,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 393:
       ACCEPT_TOKEN(anon_sym_EQ);
@@ -3694,7 +3747,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 397:
       ACCEPT_TOKEN(aux_sym_keywords_section_token1);
@@ -3705,32 +3758,32 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 398:
       ACCEPT_TOKEN(anon_sym_SPACE);
       if (lookahead == '\t') ADVANCE(36);
-      if (lookahead == ' ') ADVANCE(601);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == ' ') ADVANCE(604);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       END_STATE();
     case 399:
       ACCEPT_TOKEN(anon_sym_SPACE);
       if (lookahead == '\t') ADVANCE(12);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == ' ') ADVANCE(599);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == ' ') ADVANCE(602);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       if (lookahead == 0x0b ||
           lookahead == '\f') ADVANCE(15);
       END_STATE();
     case 400:
       ACCEPT_TOKEN(anon_sym_SPACE);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(12);
       if (lookahead == 0x0b ||
@@ -3738,7 +3791,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 401:
       ACCEPT_TOKEN(anon_sym_SPACE);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == '#') ADVANCE(600);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(36);
       END_STATE();
@@ -3748,6 +3801,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(464);
       if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']' &&
           lookahead != '{' &&
           lookahead != '}' &&
           lookahead != 0x17f &&
@@ -3786,7 +3841,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 412:
       ACCEPT_TOKEN(aux_sym_test_cases_section_token2);
@@ -3800,7 +3855,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 414:
       ACCEPT_TOKEN(aux_sym_test_cases_section_token2);
@@ -3811,7 +3866,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 415:
       ACCEPT_TOKEN(aux_sym_test_case_setting_name_token1);
@@ -3841,13 +3896,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 423:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == '#') ADVANCE(600);
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(36);
       END_STATE();
     case 424:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
-      if (lookahead == '.') ADVANCE(71);
+      if (lookahead == '.') ADVANCE(72);
       END_STATE();
     case 425:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
@@ -3859,7 +3914,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 427:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
-      if (lookahead == 'H') ADVANCE(90);
+      if (lookahead == 'H') ADVANCE(91);
       END_STATE();
     case 428:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
@@ -3869,23 +3924,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 429:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
       if (lookahead == 'L') ADVANCE(115);
-      if (lookahead == 'N') ADVANCE(77);
+      if (lookahead == 'N') ADVANCE(78);
       END_STATE();
     case 430:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
       if (lookahead == 'L') ADVANCE(115);
-      if (lookahead == 'N') ADVANCE(77);
-      if (lookahead == 'X') ADVANCE(76);
+      if (lookahead == 'N') ADVANCE(78);
+      if (lookahead == 'X') ADVANCE(77);
       END_STATE();
     case 431:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
       if (lookahead == 'L') ADVANCE(116);
-      if (lookahead == 'N') ADVANCE(77);
-      if (lookahead == 'X') ADVANCE(76);
+      if (lookahead == 'N') ADVANCE(78);
+      if (lookahead == 'X') ADVANCE(77);
       END_STATE();
     case 432:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
-      if (lookahead == 'N') ADVANCE(77);
+      if (lookahead == 'N') ADVANCE(78);
       END_STATE();
     case 433:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
@@ -3897,7 +3952,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 435:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
-      if (lookahead == 'R') ADVANCE(78);
+      if (lookahead == 'R') ADVANCE(79);
       END_STATE();
     case 436:
       ACCEPT_TOKEN(aux_sym_keyword_token1);
@@ -3912,7 +3967,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(597);
+          lookahead != 0x212a) ADVANCE(600);
       END_STATE();
     case 439:
       ACCEPT_TOKEN(anon_sym_IF);
@@ -3928,7 +3983,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 443:
       ACCEPT_TOKEN(anon_sym_ELSE);
-      if (lookahead == ' ') ADVANCE(91);
+      if (lookahead == ' ') ADVANCE(92);
       END_STATE();
     case 444:
       ACCEPT_TOKEN(anon_sym_TRY);
@@ -3947,7 +4002,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 449:
       ACCEPT_TOKEN(anon_sym_IN);
-      if (lookahead == ' ') ADVANCE(87);
+      if (lookahead == ' ') ADVANCE(88);
       END_STATE();
     case 450:
       ACCEPT_TOKEN(anon_sym_INRANGE);
@@ -3992,7 +4047,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 460:
       ACCEPT_TOKEN(aux_sym_inline_python_expression_token1);
       if (lookahead == '\r' ||
-          lookahead == '}') ADVANCE(597);
+          lookahead == '}') ADVANCE(600);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != 0x17f &&
@@ -4013,8 +4068,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 463:
       ACCEPT_TOKEN(sym_variable_name);
       if (lookahead == '\n') ADVANCE(465);
-      if (lookahead == '{' ||
-          lookahead == '}') ADVANCE(597);
+      if (lookahead == '[' ||
+          lookahead == ']' ||
+          lookahead == '{' ||
+          lookahead == '}') ADVANCE(600);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(463);
@@ -4025,6 +4082,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\t' ||
           lookahead == ' ') ADVANCE(464);
       if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']' &&
           lookahead != '{' &&
           lookahead != '}' &&
           lookahead != 0x17f &&
@@ -4033,113 +4092,139 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 465:
       ACCEPT_TOKEN(sym_variable_name);
       if (lookahead != 0 &&
+          lookahead != '[' &&
+          lookahead != ']' &&
           lookahead != '{' &&
           lookahead != '}' &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(465);
       END_STATE();
     case 466:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(131);
-      if (lookahead == ' ') ADVANCE(593);
-      if (lookahead == '{') ADVANCE(469);
+      ACCEPT_TOKEN(sym_variable_key);
+      if (lookahead == '\n') ADVANCE(468);
       if (lookahead == '$' ||
           lookahead == '&' ||
-          lookahead == '@') ADVANCE(591);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(595);
+          lookahead == '@' ||
+          lookahead == '[' ||
+          lookahead == ']' ||
+          lookahead == '}') ADVANCE(600);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(467);
+          lookahead != 0x212a) ADVANCE(466);
       END_STATE();
     case 467:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(131);
-      if (lookahead == ' ') ADVANCE(593);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(591);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(595);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(467);
+      ACCEPT_TOKEN(sym_variable_key);
+      if (lookahead == '#') ADVANCE(466);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(467);
+      if ((!eof && set_contains(sym_variable_key_character_set_1, 9, lookahead))) ADVANCE(468);
       END_STATE();
     case 468:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(131);
-      if (lookahead == ' ') ADVANCE(593);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(591);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == '{') ADVANCE(595);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(467);
+      ACCEPT_TOKEN(sym_variable_key);
+      if ((!eof && set_contains(sym_variable_key_character_set_1, 9, lookahead))) ADVANCE(468);
       END_STATE();
     case 469:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(136);
-      if (lookahead == ' ') ADVANCE(594);
-      if (lookahead == '{') ADVANCE(466);
+      if (lookahead == '\n') ADVANCE(131);
+      if (lookahead == ' ') ADVANCE(596);
+      if (lookahead == '{') ADVANCE(472);
       if (lookahead == '$' ||
           lookahead == '&' ||
-          lookahead == '@') ADVANCE(592);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(596);
+          lookahead == '@') ADVANCE(594);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(598);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(470);
       END_STATE();
     case 470:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(136);
-      if (lookahead == ' ') ADVANCE(594);
+      if (lookahead == '\n') ADVANCE(131);
+      if (lookahead == ' ') ADVANCE(596);
       if (lookahead == '$' ||
           lookahead == '&' ||
-          lookahead == '@') ADVANCE(592);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(596);
+          lookahead == '@') ADVANCE(594);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(598);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(470);
       END_STATE();
     case 471:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == '\n') ADVANCE(136);
-      if (lookahead == ' ') ADVANCE(594);
+      if (lookahead == '\n') ADVANCE(131);
+      if (lookahead == ' ') ADVANCE(596);
       if (lookahead == '$' ||
           lookahead == '&' ||
-          lookahead == '@') ADVANCE(592);
+          lookahead == '@') ADVANCE(594);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == '{') ADVANCE(596);
+          lookahead == '{') ADVANCE(598);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(470);
       END_STATE();
     case 472:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '*') ADVANCE(473);
-      if (lookahead == '{') ADVANCE(521);
+      if (lookahead == '\n') ADVANCE(136);
+      if (lookahead == ' ') ADVANCE(597);
+      if (lookahead == '{') ADVANCE(469);
       if (lookahead == '$' ||
           lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+          lookahead == '@') ADVANCE(595);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(599);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(473);
       END_STATE();
     case 473:
       ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == '\n') ADVANCE(136);
+      if (lookahead == ' ') ADVANCE(597);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(595);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(599);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(473);
+      END_STATE();
+    case 474:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == '\n') ADVANCE(136);
+      if (lookahead == ' ') ADVANCE(597);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(595);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == '{') ADVANCE(599);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(473);
+      END_STATE();
+    case 475:
+      ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '*') ADVANCE(577);
+      if (lookahead == '*') ADVANCE(476);
+      if (lookahead == '{') ADVANCE(524);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 474:
+    case 476:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == '*') ADVANCE(580);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 477:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '*') ADVANCE(413);
@@ -4149,9 +4234,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 475:
+    case 478:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '*') ADVANCE(361);
@@ -4161,9 +4246,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 476:
+    case 479:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '*') ADVANCE(396);
@@ -4173,9 +4258,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 477:
+    case 480:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '*') ADVANCE(368);
@@ -4185,9 +4270,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 478:
+    case 481:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '*') ADVANCE(391);
@@ -4197,43 +4282,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 479:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '*') ADVANCE(474);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 480:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '*') ADVANCE(475);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 481:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '*') ADVANCE(476);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 482:
       ACCEPT_TOKEN(sym__text_chunk);
@@ -4245,7 +4294,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 483:
       ACCEPT_TOKEN(sym__text_chunk);
@@ -4257,40 +4306,76 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 484:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '{') ADVANCE(521);
+      if (lookahead == '*') ADVANCE(479);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 485:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == '{') ADVANCE(535);
+      if (lookahead == '*') ADVANCE(480);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 486:
       ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == '*') ADVANCE(481);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 487:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == '{') ADVANCE(524);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 488:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == '{') ADVANCE(538);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 489:
+      ACCEPT_TOKEN(sym__text_chunk);
       ADVANCE_MAP(
         ' ', 135,
-        'A', 508,
-        'a', 508,
-        'E', 510,
-        'e', 510,
+        'A', 511,
+        'a', 511,
+        'E', 513,
+        'e', 513,
         '$', 354,
         '&', 354,
         '@', 354,
@@ -4298,451 +4383,451 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 487:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(506);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 488:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(489);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 489:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'B' ||
-          lookahead == 'b') ADVANCE(499);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 490:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'D' ||
-          lookahead == 'd') ADVANCE(512);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(509);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 491:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(520);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(492);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 492:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(516);
+      if (lookahead == 'B' ||
+          lookahead == 'b') ADVANCE(502);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 493:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(503);
+      if (lookahead == 'D' ||
+          lookahead == 'd') ADVANCE(515);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 494:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(514);
+          lookahead == 'e') ADVANCE(523);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 495:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'G' ||
-          lookahead == 'g') ADVANCE(513);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(519);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 496:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(502);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(506);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 497:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(488);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(517);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 498:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(509);
+      if (lookahead == 'G' ||
+          lookahead == 'g') ADVANCE(516);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 499:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(494);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(505);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 500:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(501);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(491);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 501:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(493);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(512);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 502:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(495);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(497);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 503:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(518);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(504);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 504:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(500);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(496);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 505:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(507);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(498);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 506:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(497);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(521);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 507:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(490);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(503);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 508:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(498);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(510);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 509:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(580);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(500);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 510:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(515);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(493);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 511:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(582);
+          lookahead == 's') ADVANCE(501);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 512:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(584);
+          lookahead == 's') ADVANCE(583);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 513:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(586);
+          lookahead == 's') ADVANCE(518);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 514:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(588);
+          lookahead == 's') ADVANCE(585);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 515:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(578);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(587);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 516:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(517);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(589);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 517:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(496);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(591);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 518:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(511);
+          lookahead == 't') ADVANCE(581);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 519:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'W' ||
-          lookahead == 'w') ADVANCE(505);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(520);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 520:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(519);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(499);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(354);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 521:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(514);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 522:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(508);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 523:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(135);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(522);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 524:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '$' ||
@@ -4751,9 +4836,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 522:
+    case 525:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(135);
       if (lookahead == '$' ||
@@ -4763,9 +4848,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '{') ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 523:
+    case 526:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(411);
@@ -4775,9 +4860,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 524:
+    case 527:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(414);
@@ -4787,9 +4872,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 525:
+    case 528:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(362);
@@ -4799,9 +4884,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 526:
+    case 529:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(397);
@@ -4811,9 +4896,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 527:
+    case 530:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(369);
@@ -4823,9 +4908,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 528:
+    case 531:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '*') ADVANCE(392);
@@ -4835,43 +4920,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 529:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == '*') ADVANCE(524);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 530:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == '*') ADVANCE(525);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 531:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == '*') ADVANCE(526);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 532:
       ACCEPT_TOKEN(sym__text_chunk);
@@ -4883,7 +4932,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 533:
       ACCEPT_TOKEN(sym__text_chunk);
@@ -4895,66 +4944,102 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 534:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == '*') ADVANCE(523);
+      if (lookahead == '*') ADVANCE(529);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 535:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == '{') ADVANCE(485);
+      if (lookahead == '*') ADVANCE(530);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 536:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(558);
+      if (lookahead == '*') ADVANCE(531);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 537:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(540);
+      if (lookahead == '*') ADVANCE(526);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 538:
       ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == '{') ADVANCE(488);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 539:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(561);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 540:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'A' ||
+          lookahead == 'a') ADVANCE(543);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 541:
+      ACCEPT_TOKEN(sym__text_chunk);
       ADVANCE_MAP(
         ' ', 353,
-        'A', 560,
-        'a', 560,
-        'E', 562,
-        'e', 562,
+        'A', 563,
+        'a', 563,
+        'E', 565,
+        'e', 565,
         '$', 355,
         '&', 355,
         '@', 355,
@@ -4962,48 +5047,61 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 539:
+    case 542:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'A' ||
-          lookahead == 'a') ADVANCE(568);
+          lookahead == 'a') ADVANCE(571);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 540:
+    case 543:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'B' ||
-          lookahead == 'b') ADVANCE(551);
+          lookahead == 'b') ADVANCE(554);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 541:
+    case 544:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'D' ||
-          lookahead == 'd') ADVANCE(564);
+          lookahead == 'd') ADVANCE(567);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 542:
+    case 545:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(577);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 546:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'E' ||
@@ -5014,321 +5112,282 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 543:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(571);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 544:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(555);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 545:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(566);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 546:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(567);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 547:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'G' ||
-          lookahead == 'g') ADVANCE(565);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(558);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 548:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(537);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(569);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 549:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'I' ||
-          lookahead == 'i') ADVANCE(554);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(570);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 550:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'K' ||
-          lookahead == 'k') ADVANCE(561);
+      if (lookahead == 'G' ||
+          lookahead == 'g') ADVANCE(568);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 551:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'L' ||
-          lookahead == 'l') ADVANCE(545);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(540);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 552:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(553);
+      if (lookahead == 'I' ||
+          lookahead == 'i') ADVANCE(557);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 553:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'M' ||
-          lookahead == 'm') ADVANCE(544);
+      if (lookahead == 'K' ||
+          lookahead == 'k') ADVANCE(564);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 554:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(547);
+      if (lookahead == 'L' ||
+          lookahead == 'l') ADVANCE(548);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 555:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'N' ||
-          lookahead == 'n') ADVANCE(572);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(556);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 556:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(552);
+      if (lookahead == 'M' ||
+          lookahead == 'm') ADVANCE(547);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 557:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'O' ||
-          lookahead == 'o') ADVANCE(559);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(550);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 558:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(548);
+      if (lookahead == 'N' ||
+          lookahead == 'n') ADVANCE(575);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 559:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'R' ||
-          lookahead == 'r') ADVANCE(541);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(555);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 560:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(550);
+      if (lookahead == 'O' ||
+          lookahead == 'o') ADVANCE(562);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 561:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(581);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(551);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 562:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(569);
+      if (lookahead == 'R' ||
+          lookahead == 'r') ADVANCE(544);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 563:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(583);
+          lookahead == 's') ADVANCE(553);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 564:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(585);
+          lookahead == 's') ADVANCE(584);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 565:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(587);
+          lookahead == 's') ADVANCE(572);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 566:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(589);
+          lookahead == 's') ADVANCE(586);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 567:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(588);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 568:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'S' ||
@@ -5339,100 +5398,126 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 568:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'S' ||
-          lookahead == 's') ADVANCE(546);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 569:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(579);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(592);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 570:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(549);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(593);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 571:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(570);
+      if (lookahead == 'S' ||
+          lookahead == 's') ADVANCE(549);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 572:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == 'T' ||
-          lookahead == 't') ADVANCE(563);
+          lookahead == 't') ADVANCE(582);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 573:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'W' ||
-          lookahead == 'w') ADVANCE(557);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(552);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 574:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
-      if (lookahead == 'Y' ||
-          lookahead == 'y') ADVANCE(573);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(573);
       if (lookahead == '$' ||
           lookahead == '&' ||
           lookahead == '@') ADVANCE(355);
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 575:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'T' ||
+          lookahead == 't') ADVANCE(566);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 576:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'W' ||
+          lookahead == 'w') ADVANCE(560);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 577:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(353);
+      if (lookahead == 'Y' ||
+          lookahead == 'y') ADVANCE(576);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 578:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '$' ||
@@ -5441,9 +5526,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 576:
+    case 579:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(353);
       if (lookahead == '$' ||
@@ -5453,22 +5538,22 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead == '{') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 577:
+    case 580:
       ACCEPT_TOKEN(sym__text_chunk);
       ADVANCE_MAP(
         ' ', 133,
-        'C', 504,
-        'c', 504,
-        'K', 491,
-        'k', 491,
-        'S', 492,
-        's', 492,
-        'T', 486,
-        't', 486,
-        'V', 487,
-        'v', 487,
+        'C', 507,
+        'c', 507,
+        'K', 494,
+        'k', 494,
+        'S', 495,
+        's', 495,
+        'T', 489,
+        't', 489,
+        'V', 490,
+        'v', 490,
         '$', 354,
         '&', 354,
         '@', 354,
@@ -5476,9 +5561,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 578:
+    case 581:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(134);
       if (lookahead == '$' ||
@@ -5487,9 +5572,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 579:
+    case 582:
       ACCEPT_TOKEN(sym__text_chunk);
       if (lookahead == ' ') ADVANCE(168);
       if (lookahead == '$' ||
@@ -5498,83 +5583,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 580:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(50);
-      if (lookahead == '*') ADVANCE(479);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 581:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(51);
-      if (lookahead == '*') ADVANCE(529);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 582:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(55);
-      if (lookahead == '*') ADVANCE(480);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
     case 583:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(56);
-      if (lookahead == '*') ADVANCE(530);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 584:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(58);
-      if (lookahead == '*') ADVANCE(481);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(354);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
-      END_STATE();
-    case 585:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(59);
-      if (lookahead == '*') ADVANCE(531);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(355);
-      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
-      END_STATE();
-    case 586:
-      ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(61);
+      if (lookahead == ' ') ADVANCE(51);
       if (lookahead == '*') ADVANCE(482);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -5582,11 +5595,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 587:
+    case 584:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(62);
+      if (lookahead == ' ') ADVANCE(52);
       if (lookahead == '*') ADVANCE(532);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -5594,11 +5607,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 588:
+    case 585:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(64);
+      if (lookahead == ' ') ADVANCE(56);
       if (lookahead == '*') ADVANCE(483);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -5606,11 +5619,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(521);
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
-    case 589:
+    case 586:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(65);
+      if (lookahead == ' ') ADVANCE(57);
       if (lookahead == '*') ADVANCE(533);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -5618,11 +5631,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 590:
+    case 587:
       ACCEPT_TOKEN(sym__text_chunk);
-      if (lookahead == ' ') ADVANCE(67);
+      if (lookahead == ' ') ADVANCE(59);
+      if (lookahead == '*') ADVANCE(484);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 588:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(60);
       if (lookahead == '*') ADVANCE(534);
       if (lookahead == '$' ||
           lookahead == '&' ||
@@ -5630,160 +5655,220 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(575);
+          lookahead != 0x212a) ADVANCE(578);
       END_STATE();
-    case 591:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\n') ADVANCE(522);
-      if (lookahead == '{') ADVANCE(597);
+    case 589:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(62);
+      if (lookahead == '*') ADVANCE(485);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(468);
+          lookahead != 0x212a) ADVANCE(524);
+      END_STATE();
+    case 590:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(63);
+      if (lookahead == '*') ADVANCE(535);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 591:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(65);
+      if (lookahead == '*') ADVANCE(486);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(354);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(131);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(524);
       END_STATE();
     case 592:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(66);
+      if (lookahead == '*') ADVANCE(536);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 593:
+      ACCEPT_TOKEN(sym__text_chunk);
+      if (lookahead == ' ') ADVANCE(68);
+      if (lookahead == '*') ADVANCE(537);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(355);
+      if (('\t' <= lookahead && lookahead <= '\r')) ADVANCE(136);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(578);
+      END_STATE();
+    case 594:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\n') ADVANCE(576);
-      if (lookahead == '{') ADVANCE(597);
+      if (lookahead == '\n') ADVANCE(525);
+      if (lookahead == '{') ADVANCE(600);
       if (lookahead != 0 &&
           lookahead != 0x17f &&
           lookahead != 0x212a) ADVANCE(471);
       END_STATE();
-    case 593:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\n') ADVANCE(136);
-      if (lookahead == '{') ADVANCE(466);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(592);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(596);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(470);
-      END_STATE();
-    case 594:
-      ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '\n') ADVANCE(136);
-      if (lookahead == '$' ||
-          lookahead == '&' ||
-          lookahead == '@') ADVANCE(592);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(596);
-      if (lookahead != 0 &&
-          lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(470);
-      END_STATE();
     case 595:
       ACCEPT_TOKEN(sym_comment);
-      if (lookahead == '{') ADVANCE(468);
+      if (lookahead == '\n') ADVANCE(579);
+      if (lookahead == '{') ADVANCE(600);
       if (lookahead != 0 &&
-          lookahead != '\n' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(597);
+          lookahead != 0x212a) ADVANCE(474);
       END_STATE();
     case 596:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\n') ADVANCE(136);
+      if (lookahead == '{') ADVANCE(469);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(595);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(599);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(473);
+      END_STATE();
+    case 597:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '\n') ADVANCE(136);
+      if (lookahead == '$' ||
+          lookahead == '&' ||
+          lookahead == '@') ADVANCE(595);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(599);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(473);
+      END_STATE();
+    case 598:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead == '{') ADVANCE(471);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(597);
+          lookahead != 0x212a) ADVANCE(600);
       END_STATE();
-    case 597:
+    case 599:
+      ACCEPT_TOKEN(sym_comment);
+      if (lookahead == '{') ADVANCE(474);
+      if (lookahead != 0 &&
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(600);
+      END_STATE();
+    case 600:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != 0x17f &&
-          lookahead != 0x212a) ADVANCE(597);
-      END_STATE();
-    case 598:
-      ACCEPT_TOKEN(sym__separator);
-      if (lookahead == '\n') ADVANCE(603);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(599);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
-      END_STATE();
-    case 599:
-      ACCEPT_TOKEN(sym__separator);
-      if (lookahead == '\n') ADVANCE(603);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(599);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
-      END_STATE();
-    case 600:
-      ACCEPT_TOKEN(sym__separator);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(601);
+          lookahead != 0x212a) ADVANCE(600);
       END_STATE();
     case 601:
       ACCEPT_TOKEN(sym__separator);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == '\n') ADVANCE(606);
+      if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(601);
+          lookahead == ' ') ADVANCE(602);
+      if (lookahead == 0x0b ||
+          lookahead == '\f') ADVANCE(15);
       END_STATE();
     case 602:
-      ACCEPT_TOKEN(sym__line_break);
-      if (lookahead == '\n') ADVANCE(603);
+      ACCEPT_TOKEN(sym__separator);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '{') ADVANCE(522);
-      if (('\t' <= lookahead && lookahead <= '\f') ||
-          lookahead == ' ') ADVANCE(15);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(602);
+      if (lookahead == 0x0b ||
+          lookahead == '\f') ADVANCE(15);
       END_STATE();
     case 603:
+      ACCEPT_TOKEN(sym__separator);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(604);
+      END_STATE();
+    case 604:
+      ACCEPT_TOKEN(sym__separator);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(604);
+      END_STATE();
+    case 605:
       ACCEPT_TOKEN(sym__line_break);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == '{') ADVANCE(525);
       if (('\t' <= lookahead && lookahead <= '\f') ||
           lookahead == ' ') ADVANCE(15);
       END_STATE();
-    case 604:
-      ACCEPT_TOKEN(aux_sym__empty_line_token1);
-      if (lookahead == '\t') ADVANCE(607);
-      if (lookahead == '\n') ADVANCE(603);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == ' ') ADVANCE(599);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
-      END_STATE();
-    case 605:
-      ACCEPT_TOKEN(aux_sym__empty_line_token1);
-      if (lookahead == '\t') ADVANCE(607);
-      if (lookahead == '\n') ADVANCE(603);
-      if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == ' ') ADVANCE(599);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
-      END_STATE();
     case 606:
-      ACCEPT_TOKEN(aux_sym__empty_line_token1);
-      if (lookahead == '\n') ADVANCE(603);
+      ACCEPT_TOKEN(sym__line_break);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
-      if (lookahead == '{') ADVANCE(522);
-      if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(607);
-      if (lookahead == 0x0b ||
-          lookahead == '\f') ADVANCE(15);
+      if (('\t' <= lookahead && lookahead <= '\f') ||
+          lookahead == ' ') ADVANCE(15);
       END_STATE();
     case 607:
       ACCEPT_TOKEN(aux_sym__empty_line_token1);
-      if (lookahead == '\n') ADVANCE(603);
+      if (lookahead == '\t') ADVANCE(610);
+      if (lookahead == '\n') ADVANCE(606);
       if (lookahead == '\r') ADVANCE(15);
-      if (lookahead == '#') ADVANCE(597);
+      if (lookahead == ' ') ADVANCE(602);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
+      if (lookahead == 0x0b ||
+          lookahead == '\f') ADVANCE(15);
+      END_STATE();
+    case 608:
+      ACCEPT_TOKEN(aux_sym__empty_line_token1);
+      if (lookahead == '\t') ADVANCE(610);
+      if (lookahead == '\n') ADVANCE(606);
+      if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == ' ') ADVANCE(602);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == 0x0b ||
+          lookahead == '\f') ADVANCE(15);
+      END_STATE();
+    case 609:
+      ACCEPT_TOKEN(aux_sym__empty_line_token1);
+      if (lookahead == '\n') ADVANCE(606);
+      if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '{') ADVANCE(525);
       if (lookahead == '\t' ||
-          lookahead == ' ') ADVANCE(607);
+          lookahead == ' ') ADVANCE(610);
+      if (lookahead == 0x0b ||
+          lookahead == '\f') ADVANCE(15);
+      END_STATE();
+    case 610:
+      ACCEPT_TOKEN(aux_sym__empty_line_token1);
+      if (lookahead == '\n') ADVANCE(606);
+      if (lookahead == '\r') ADVANCE(15);
+      if (lookahead == '#') ADVANCE(600);
+      if (lookahead == '\t' ||
+          lookahead == ' ') ADVANCE(610);
       if (lookahead == 0x0b ||
           lookahead == '\f') ADVANCE(15);
       END_STATE();
@@ -5820,37 +5905,37 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [24] = {.lex_state = 358},
   [25] = {.lex_state = 358},
   [26] = {.lex_state = 358},
-  [27] = {.lex_state = 358},
-  [28] = {.lex_state = 357},
+  [27] = {.lex_state = 357},
+  [28] = {.lex_state = 358},
   [29] = {.lex_state = 358},
-  [30] = {.lex_state = 358},
+  [30] = {.lex_state = 357},
   [31] = {.lex_state = 356},
   [32] = {.lex_state = 356},
-  [33] = {.lex_state = 357},
-  [34] = {.lex_state = 358},
-  [35] = {.lex_state = 356},
-  [36] = {.lex_state = 356},
+  [33] = {.lex_state = 356},
+  [34] = {.lex_state = 356},
+  [35] = {.lex_state = 358},
+  [36] = {.lex_state = 358},
   [37] = {.lex_state = 358},
   [38] = {.lex_state = 357},
   [39] = {.lex_state = 357},
   [40] = {.lex_state = 357},
   [41] = {.lex_state = 3},
-  [42] = {.lex_state = 356},
-  [43] = {.lex_state = 3},
-  [44] = {.lex_state = 3},
-  [45] = {.lex_state = 4},
-  [46] = {.lex_state = 356},
-  [47] = {.lex_state = 356},
-  [48] = {.lex_state = 357},
-  [49] = {.lex_state = 3},
+  [42] = {.lex_state = 357},
+  [43] = {.lex_state = 357},
+  [44] = {.lex_state = 357},
+  [45] = {.lex_state = 3},
+  [46] = {.lex_state = 3},
+  [47] = {.lex_state = 4},
+  [48] = {.lex_state = 356},
+  [49] = {.lex_state = 356},
   [50] = {.lex_state = 357},
-  [51] = {.lex_state = 3},
-  [52] = {.lex_state = 357},
+  [51] = {.lex_state = 357},
+  [52] = {.lex_state = 3},
   [53] = {.lex_state = 3},
-  [54] = {.lex_state = 357},
+  [54] = {.lex_state = 3},
   [55] = {.lex_state = 3},
   [56] = {.lex_state = 3},
-  [57] = {.lex_state = 357},
+  [57] = {.lex_state = 356},
   [58] = {.lex_state = 3},
   [59] = {.lex_state = 4},
   [60] = {.lex_state = 3},
@@ -5858,9 +5943,9 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [62] = {.lex_state = 357},
   [63] = {.lex_state = 3},
   [64] = {.lex_state = 358},
-  [65] = {.lex_state = 358},
+  [65] = {.lex_state = 3},
   [66] = {.lex_state = 358},
-  [67] = {.lex_state = 3},
+  [67] = {.lex_state = 358},
   [68] = {.lex_state = 357},
   [69] = {.lex_state = 7},
   [70] = {.lex_state = 7},
@@ -5868,315 +5953,315 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [72] = {.lex_state = 8},
   [73] = {.lex_state = 8},
   [74] = {.lex_state = 8},
-  [75] = {.lex_state = 5},
-  [76] = {.lex_state = 3},
-  [77] = {.lex_state = 1},
-  [78] = {.lex_state = 35},
-  [79] = {.lex_state = 1},
-  [80] = {.lex_state = 3},
-  [81] = {.lex_state = 5},
-  [82] = {.lex_state = 4},
-  [83] = {.lex_state = 3},
-  [84] = {.lex_state = 5},
-  [85] = {.lex_state = 35},
-  [86] = {.lex_state = 35},
+  [75] = {.lex_state = 3},
+  [76] = {.lex_state = 1},
+  [77] = {.lex_state = 4},
+  [78] = {.lex_state = 1},
+  [79] = {.lex_state = 5},
+  [80] = {.lex_state = 35},
+  [81] = {.lex_state = 3},
+  [82] = {.lex_state = 35},
+  [83] = {.lex_state = 5},
+  [84] = {.lex_state = 35},
+  [85] = {.lex_state = 5},
+  [86] = {.lex_state = 3},
   [87] = {.lex_state = 3},
   [88] = {.lex_state = 3},
   [89] = {.lex_state = 4},
   [90] = {.lex_state = 4},
-  [91] = {.lex_state = 357},
+  [91] = {.lex_state = 4},
   [92] = {.lex_state = 4},
-  [93] = {.lex_state = 4},
+  [93] = {.lex_state = 357},
   [94] = {.lex_state = 4},
   [95] = {.lex_state = 4},
   [96] = {.lex_state = 4},
-  [97] = {.lex_state = 4},
-  [98] = {.lex_state = 4},
-  [99] = {.lex_state = 357},
-  [100] = {.lex_state = 357},
+  [97] = {.lex_state = 357},
+  [98] = {.lex_state = 357},
+  [99] = {.lex_state = 4},
+  [100] = {.lex_state = 4},
   [101] = {.lex_state = 4},
   [102] = {.lex_state = 4},
   [103] = {.lex_state = 4},
-  [104] = {.lex_state = 4},
-  [105] = {.lex_state = 3},
-  [106] = {.lex_state = 4},
-  [107] = {.lex_state = 3},
-  [108] = {.lex_state = 4},
+  [104] = {.lex_state = 3},
+  [105] = {.lex_state = 4},
+  [106] = {.lex_state = 9},
+  [107] = {.lex_state = 4},
+  [108] = {.lex_state = 9},
   [109] = {.lex_state = 4},
   [110] = {.lex_state = 4},
   [111] = {.lex_state = 4},
   [112] = {.lex_state = 4},
-  [113] = {.lex_state = 4},
+  [113] = {.lex_state = 9},
   [114] = {.lex_state = 4},
   [115] = {.lex_state = 3},
   [116] = {.lex_state = 4},
-  [117] = {.lex_state = 9},
-  [118] = {.lex_state = 3},
+  [117] = {.lex_state = 4},
+  [118] = {.lex_state = 4},
   [119] = {.lex_state = 3},
   [120] = {.lex_state = 4},
-  [121] = {.lex_state = 3},
-  [122] = {.lex_state = 3},
-  [123] = {.lex_state = 3},
-  [124] = {.lex_state = 4},
-  [125] = {.lex_state = 4},
+  [121] = {.lex_state = 4},
+  [122] = {.lex_state = 4},
+  [123] = {.lex_state = 4},
+  [124] = {.lex_state = 3},
+  [125] = {.lex_state = 3},
   [126] = {.lex_state = 3},
   [127] = {.lex_state = 3},
   [128] = {.lex_state = 3},
-  [129] = {.lex_state = 4},
-  [130] = {.lex_state = 4},
+  [129] = {.lex_state = 3},
+  [130] = {.lex_state = 3},
   [131] = {.lex_state = 3},
   [132] = {.lex_state = 4},
   [133] = {.lex_state = 3},
-  [134] = {.lex_state = 4},
-  [135] = {.lex_state = 9},
+  [134] = {.lex_state = 3},
+  [135] = {.lex_state = 3},
   [136] = {.lex_state = 3},
-  [137] = {.lex_state = 9},
-  [138] = {.lex_state = 3},
+  [137] = {.lex_state = 3},
+  [138] = {.lex_state = 4},
   [139] = {.lex_state = 3},
-  [140] = {.lex_state = 9},
+  [140] = {.lex_state = 4},
   [141] = {.lex_state = 8},
-  [142] = {.lex_state = 3},
-  [143] = {.lex_state = 9},
+  [142] = {.lex_state = 7},
+  [143] = {.lex_state = 7},
   [144] = {.lex_state = 3},
   [145] = {.lex_state = 9},
-  [146] = {.lex_state = 4},
-  [147] = {.lex_state = 7},
+  [146] = {.lex_state = 5},
+  [147] = {.lex_state = 5},
   [148] = {.lex_state = 7},
-  [149] = {.lex_state = 7},
-  [150] = {.lex_state = 7},
+  [149] = {.lex_state = 5},
+  [150] = {.lex_state = 9},
   [151] = {.lex_state = 7},
-  [152] = {.lex_state = 7},
+  [152] = {.lex_state = 5},
   [153] = {.lex_state = 7},
-  [154] = {.lex_state = 8},
+  [154] = {.lex_state = 7},
   [155] = {.lex_state = 7},
-  [156] = {.lex_state = 7},
-  [157] = {.lex_state = 7},
-  [158] = {.lex_state = 8},
-  [159] = {.lex_state = 8},
-  [160] = {.lex_state = 7},
-  [161] = {.lex_state = 7},
+  [156] = {.lex_state = 4},
+  [157] = {.lex_state = 4},
+  [158] = {.lex_state = 7},
+  [159] = {.lex_state = 7},
+  [160] = {.lex_state = 8},
+  [161] = {.lex_state = 8},
   [162] = {.lex_state = 7},
-  [163] = {.lex_state = 8},
-  [164] = {.lex_state = 8},
-  [165] = {.lex_state = 8},
+  [163] = {.lex_state = 7},
+  [164] = {.lex_state = 7},
+  [165] = {.lex_state = 7},
   [166] = {.lex_state = 8},
   [167] = {.lex_state = 8},
   [168] = {.lex_state = 8},
   [169] = {.lex_state = 8},
   [170] = {.lex_state = 8},
   [171] = {.lex_state = 8},
-  [172] = {.lex_state = 4},
-  [173] = {.lex_state = 9},
-  [174] = {.lex_state = 37},
-  [175] = {.lex_state = 357},
-  [176] = {.lex_state = 5},
-  [177] = {.lex_state = 5},
-  [178] = {.lex_state = 5},
-  [179] = {.lex_state = 37},
-  [180] = {.lex_state = 5},
-  [181] = {.lex_state = 4},
-  [182] = {.lex_state = 5},
-  [183] = {.lex_state = 9},
+  [172] = {.lex_state = 8},
+  [173] = {.lex_state = 8},
+  [174] = {.lex_state = 8},
+  [175] = {.lex_state = 8},
+  [176] = {.lex_state = 8},
+  [177] = {.lex_state = 3},
+  [178] = {.lex_state = 9},
+  [179] = {.lex_state = 7},
+  [180] = {.lex_state = 1},
+  [181] = {.lex_state = 1},
+  [182] = {.lex_state = 357},
+  [183] = {.lex_state = 357},
   [184] = {.lex_state = 5},
-  [185] = {.lex_state = 4},
-  [186] = {.lex_state = 5},
-  [187] = {.lex_state = 4},
-  [188] = {.lex_state = 3},
-  [189] = {.lex_state = 357},
-  [190] = {.lex_state = 5},
+  [185] = {.lex_state = 1},
+  [186] = {.lex_state = 1},
+  [187] = {.lex_state = 5},
+  [188] = {.lex_state = 4},
+  [189] = {.lex_state = 4},
+  [190] = {.lex_state = 9},
   [191] = {.lex_state = 5},
   [192] = {.lex_state = 4},
-  [193] = {.lex_state = 37},
-  [194] = {.lex_state = 4},
-  [195] = {.lex_state = 4},
-  [196] = {.lex_state = 37},
+  [193] = {.lex_state = 5},
+  [194] = {.lex_state = 5},
+  [195] = {.lex_state = 9},
+  [196] = {.lex_state = 1},
   [197] = {.lex_state = 37},
-  [198] = {.lex_state = 37},
-  [199] = {.lex_state = 37},
-  [200] = {.lex_state = 4},
+  [198] = {.lex_state = 3},
+  [199] = {.lex_state = 1},
+  [200] = {.lex_state = 37},
   [201] = {.lex_state = 4},
-  [202] = {.lex_state = 4},
-  [203] = {.lex_state = 4},
-  [204] = {.lex_state = 357},
+  [202] = {.lex_state = 1},
+  [203] = {.lex_state = 37},
+  [204] = {.lex_state = 4},
   [205] = {.lex_state = 4},
-  [206] = {.lex_state = 4},
-  [207] = {.lex_state = 9},
-  [208] = {.lex_state = 357},
-  [209] = {.lex_state = 4},
-  [210] = {.lex_state = 4},
-  [211] = {.lex_state = 9},
+  [206] = {.lex_state = 1},
+  [207] = {.lex_state = 1},
+  [208] = {.lex_state = 37},
+  [209] = {.lex_state = 1},
+  [210] = {.lex_state = 37},
+  [211] = {.lex_state = 1},
   [212] = {.lex_state = 37},
-  [213] = {.lex_state = 4},
-  [214] = {.lex_state = 4},
-  [215] = {.lex_state = 9},
-  [216] = {.lex_state = 357},
-  [217] = {.lex_state = 4},
-  [218] = {.lex_state = 357},
-  [219] = {.lex_state = 9},
-  [220] = {.lex_state = 4},
-  [221] = {.lex_state = 9},
-  [222] = {.lex_state = 4},
-  [223] = {.lex_state = 357},
-  [224] = {.lex_state = 357},
+  [213] = {.lex_state = 1},
+  [214] = {.lex_state = 1},
+  [215] = {.lex_state = 37},
+  [216] = {.lex_state = 1},
+  [217] = {.lex_state = 1},
+  [218] = {.lex_state = 1},
+  [219] = {.lex_state = 1},
+  [220] = {.lex_state = 1},
+  [221] = {.lex_state = 1},
+  [222] = {.lex_state = 1},
+  [223] = {.lex_state = 1},
+  [224] = {.lex_state = 5},
   [225] = {.lex_state = 4},
-  [226] = {.lex_state = 9},
-  [227] = {.lex_state = 4},
+  [226] = {.lex_state = 4},
+  [227] = {.lex_state = 37},
   [228] = {.lex_state = 9},
-  [229] = {.lex_state = 10},
-  [230] = {.lex_state = 4},
-  [231] = {.lex_state = 4},
+  [229] = {.lex_state = 4},
+  [230] = {.lex_state = 357},
+  [231] = {.lex_state = 1},
   [232] = {.lex_state = 4},
   [233] = {.lex_state = 4},
-  [234] = {.lex_state = 1},
-  [235] = {.lex_state = 9},
-  [236] = {.lex_state = 13},
-  [237] = {.lex_state = 9},
+  [234] = {.lex_state = 4},
+  [235] = {.lex_state = 4},
+  [236] = {.lex_state = 4},
+  [237] = {.lex_state = 4},
   [238] = {.lex_state = 9},
   [239] = {.lex_state = 9},
-  [240] = {.lex_state = 357},
-  [241] = {.lex_state = 4},
+  [240] = {.lex_state = 4},
+  [241] = {.lex_state = 357},
   [242] = {.lex_state = 9},
-  [243] = {.lex_state = 4},
-  [244] = {.lex_state = 13},
-  [245] = {.lex_state = 9},
-  [246] = {.lex_state = 9},
-  [247] = {.lex_state = 1},
-  [248] = {.lex_state = 13},
-  [249] = {.lex_state = 357},
-  [250] = {.lex_state = 4},
-  [251] = {.lex_state = 1},
+  [243] = {.lex_state = 9},
+  [244] = {.lex_state = 4},
+  [245] = {.lex_state = 4},
+  [246] = {.lex_state = 357},
+  [247] = {.lex_state = 4},
+  [248] = {.lex_state = 38},
+  [249] = {.lex_state = 4},
+  [250] = {.lex_state = 9},
+  [251] = {.lex_state = 4},
   [252] = {.lex_state = 4},
   [253] = {.lex_state = 4},
-  [254] = {.lex_state = 1},
-  [255] = {.lex_state = 1},
-  [256] = {.lex_state = 1},
-  [257] = {.lex_state = 9},
-  [258] = {.lex_state = 1},
-  [259] = {.lex_state = 4},
+  [254] = {.lex_state = 4},
+  [255] = {.lex_state = 357},
+  [256] = {.lex_state = 9},
+  [257] = {.lex_state = 13},
+  [258] = {.lex_state = 9},
+  [259] = {.lex_state = 9},
   [260] = {.lex_state = 357},
-  [261] = {.lex_state = 357},
-  [262] = {.lex_state = 10},
-  [263] = {.lex_state = 9},
-  [264] = {.lex_state = 1},
-  [265] = {.lex_state = 1},
-  [266] = {.lex_state = 1},
-  [267] = {.lex_state = 4},
+  [261] = {.lex_state = 4},
+  [262] = {.lex_state = 13},
+  [263] = {.lex_state = 4},
+  [264] = {.lex_state = 9},
+  [265] = {.lex_state = 4},
+  [266] = {.lex_state = 357},
+  [267] = {.lex_state = 9},
   [268] = {.lex_state = 9},
-  [269] = {.lex_state = 1},
-  [270] = {.lex_state = 13},
+  [269] = {.lex_state = 4},
+  [270] = {.lex_state = 1},
   [271] = {.lex_state = 4},
   [272] = {.lex_state = 4},
-  [273] = {.lex_state = 4},
-  [274] = {.lex_state = 1},
-  [275] = {.lex_state = 9},
-  [276] = {.lex_state = 1},
-  [277] = {.lex_state = 1},
-  [278] = {.lex_state = 1},
-  [279] = {.lex_state = 357},
-  [280] = {.lex_state = 13},
-  [281] = {.lex_state = 1},
-  [282] = {.lex_state = 1},
+  [273] = {.lex_state = 1},
+  [274] = {.lex_state = 4},
+  [275] = {.lex_state = 4},
+  [276] = {.lex_state = 4},
+  [277] = {.lex_state = 4},
+  [278] = {.lex_state = 4},
+  [279] = {.lex_state = 9},
+  [280] = {.lex_state = 10},
+  [281] = {.lex_state = 10},
+  [282] = {.lex_state = 9},
   [283] = {.lex_state = 1},
-  [284] = {.lex_state = 1},
-  [285] = {.lex_state = 1},
+  [284] = {.lex_state = 10},
+  [285] = {.lex_state = 4},
   [286] = {.lex_state = 1},
   [287] = {.lex_state = 9},
-  [288] = {.lex_state = 1},
+  [288] = {.lex_state = 357},
   [289] = {.lex_state = 1},
-  [290] = {.lex_state = 1},
-  [291] = {.lex_state = 357},
-  [292] = {.lex_state = 10},
-  [293] = {.lex_state = 1},
+  [290] = {.lex_state = 4},
+  [291] = {.lex_state = 13},
+  [292] = {.lex_state = 9},
+  [293] = {.lex_state = 9},
   [294] = {.lex_state = 1},
-  [295] = {.lex_state = 1},
-  [296] = {.lex_state = 1},
-  [297] = {.lex_state = 1},
-  [298] = {.lex_state = 1},
+  [295] = {.lex_state = 10},
+  [296] = {.lex_state = 4},
+  [297] = {.lex_state = 4},
+  [298] = {.lex_state = 9},
   [299] = {.lex_state = 1},
   [300] = {.lex_state = 1},
-  [301] = {.lex_state = 10},
-  [302] = {.lex_state = 10},
-  [303] = {.lex_state = 10},
-  [304] = {.lex_state = 4},
-  [305] = {.lex_state = 10},
-  [306] = {.lex_state = 10},
-  [307] = {.lex_state = 10},
-  [308] = {.lex_state = 10},
-  [309] = {.lex_state = 10},
-  [310] = {.lex_state = 10},
-  [311] = {.lex_state = 10},
-  [312] = {.lex_state = 4},
-  [313] = {.lex_state = 38},
-  [314] = {.lex_state = 357},
-  [315] = {.lex_state = 357},
-  [316] = {.lex_state = 357},
-  [317] = {.lex_state = 357},
-  [318] = {.lex_state = 38},
-  [319] = {.lex_state = 357},
-  [320] = {.lex_state = 357},
-  [321] = {.lex_state = 357},
+  [301] = {.lex_state = 1},
+  [302] = {.lex_state = 9},
+  [303] = {.lex_state = 1},
+  [304] = {.lex_state = 1},
+  [305] = {.lex_state = 1},
+  [306] = {.lex_state = 13},
+  [307] = {.lex_state = 1},
+  [308] = {.lex_state = 1},
+  [309] = {.lex_state = 1},
+  [310] = {.lex_state = 1},
+  [311] = {.lex_state = 13},
+  [312] = {.lex_state = 1},
+  [313] = {.lex_state = 1},
+  [314] = {.lex_state = 1},
+  [315] = {.lex_state = 1},
+  [316] = {.lex_state = 4},
+  [317] = {.lex_state = 1},
+  [318] = {.lex_state = 10},
+  [319] = {.lex_state = 10},
+  [320] = {.lex_state = 10},
+  [321] = {.lex_state = 4},
   [322] = {.lex_state = 357},
-  [323] = {.lex_state = 357},
-  [324] = {.lex_state = 357},
-  [325] = {.lex_state = 38},
-  [326] = {.lex_state = 38},
-  [327] = {.lex_state = 9},
-  [328] = {.lex_state = 9},
-  [329] = {.lex_state = 9},
-  [330] = {.lex_state = 357},
+  [323] = {.lex_state = 10},
+  [324] = {.lex_state = 10},
+  [325] = {.lex_state = 10},
+  [326] = {.lex_state = 10},
+  [327] = {.lex_state = 10},
+  [328] = {.lex_state = 10},
+  [329] = {.lex_state = 1},
+  [330] = {.lex_state = 39},
   [331] = {.lex_state = 357},
   [332] = {.lex_state = 357},
-  [333] = {.lex_state = 357},
+  [333] = {.lex_state = 9},
   [334] = {.lex_state = 357},
   [335] = {.lex_state = 357},
-  [336] = {.lex_state = 9},
+  [336] = {.lex_state = 357},
   [337] = {.lex_state = 357},
-  [338] = {.lex_state = 38},
+  [338] = {.lex_state = 357},
   [339] = {.lex_state = 357},
   [340] = {.lex_state = 357},
   [341] = {.lex_state = 357},
   [342] = {.lex_state = 357},
   [343] = {.lex_state = 357},
-  [344] = {.lex_state = 357},
-  [345] = {.lex_state = 357},
-  [346] = {.lex_state = 357},
+  [344] = {.lex_state = 9},
+  [345] = {.lex_state = 39},
+  [346] = {.lex_state = 9},
   [347] = {.lex_state = 357},
   [348] = {.lex_state = 357},
   [349] = {.lex_state = 357},
-  [350] = {.lex_state = 9},
+  [350] = {.lex_state = 357},
   [351] = {.lex_state = 357},
-  [352] = {.lex_state = 9},
+  [352] = {.lex_state = 357},
   [353] = {.lex_state = 357},
-  [354] = {.lex_state = 9},
-  [355] = {.lex_state = 9},
+  [354] = {.lex_state = 39},
+  [355] = {.lex_state = 357},
   [356] = {.lex_state = 357},
-  [357] = {.lex_state = 357},
+  [357] = {.lex_state = 4},
   [358] = {.lex_state = 9},
   [359] = {.lex_state = 357},
   [360] = {.lex_state = 357},
-  [361] = {.lex_state = 9},
+  [361] = {.lex_state = 39},
   [362] = {.lex_state = 357},
-  [363] = {.lex_state = 357},
+  [363] = {.lex_state = 9},
   [364] = {.lex_state = 357},
-  [365] = {.lex_state = 357},
-  [366] = {.lex_state = 9},
+  [365] = {.lex_state = 9},
+  [366] = {.lex_state = 357},
   [367] = {.lex_state = 357},
-  [368] = {.lex_state = 357},
-  [369] = {.lex_state = 9},
-  [370] = {.lex_state = 357},
-  [371] = {.lex_state = 357},
-  [372] = {.lex_state = 357},
+  [368] = {.lex_state = 9},
+  [369] = {.lex_state = 357},
+  [370] = {.lex_state = 9},
+  [371] = {.lex_state = 9},
+  [372] = {.lex_state = 9},
   [373] = {.lex_state = 357},
-  [374] = {.lex_state = 357},
+  [374] = {.lex_state = 9},
   [375] = {.lex_state = 357},
   [376] = {.lex_state = 357},
   [377] = {.lex_state = 357},
   [378] = {.lex_state = 357},
-  [379] = {.lex_state = 357},
+  [379] = {.lex_state = 9},
   [380] = {.lex_state = 357},
   [381] = {.lex_state = 357},
   [382] = {.lex_state = 357},
-  [383] = {.lex_state = 357},
+  [383] = {.lex_state = 39},
   [384] = {.lex_state = 357},
   [385] = {.lex_state = 357},
   [386] = {.lex_state = 357},
@@ -6187,7 +6272,7 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [391] = {.lex_state = 357},
   [392] = {.lex_state = 357},
   [393] = {.lex_state = 357},
-  [394] = {.lex_state = 9},
+  [394] = {.lex_state = 357},
   [395] = {.lex_state = 357},
   [396] = {.lex_state = 357},
   [397] = {.lex_state = 357},
@@ -6201,13 +6286,13 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [405] = {.lex_state = 357},
   [406] = {.lex_state = 357},
   [407] = {.lex_state = 357},
-  [408] = {.lex_state = 357},
+  [408] = {.lex_state = 9},
   [409] = {.lex_state = 357},
   [410] = {.lex_state = 357},
   [411] = {.lex_state = 357},
   [412] = {.lex_state = 357},
   [413] = {.lex_state = 357},
-  [414] = {.lex_state = 357},
+  [414] = {.lex_state = 9},
   [415] = {.lex_state = 357},
   [416] = {.lex_state = 357},
   [417] = {.lex_state = 357},
@@ -6218,29 +6303,53 @@ static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [422] = {.lex_state = 357},
   [423] = {.lex_state = 357},
   [424] = {.lex_state = 357},
-  [425] = {.lex_state = 9},
+  [425] = {.lex_state = 357},
   [426] = {.lex_state = 357},
   [427] = {.lex_state = 357},
-  [428] = {.lex_state = 38},
+  [428] = {.lex_state = 357},
   [429] = {.lex_state = 357},
-  [430] = {.lex_state = 38},
+  [430] = {.lex_state = 357},
   [431] = {.lex_state = 357},
-  [432] = {.lex_state = 38},
+  [432] = {.lex_state = 357},
   [433] = {.lex_state = 357},
-  [434] = {.lex_state = 357},
-  [435] = {.lex_state = 9},
-  [436] = {.lex_state = 38},
-  [437] = {.lex_state = 38},
-  [438] = {.lex_state = 38},
+  [434] = {.lex_state = 9},
+  [435] = {.lex_state = 357},
+  [436] = {.lex_state = 357},
+  [437] = {.lex_state = 357},
+  [438] = {.lex_state = 357},
   [439] = {.lex_state = 357},
-  [440] = {.lex_state = 9},
+  [440] = {.lex_state = 357},
   [441] = {.lex_state = 357},
-  [442] = {.lex_state = 38},
-  [443] = {.lex_state = 38},
-  [444] = {.lex_state = 38},
+  [442] = {.lex_state = 357},
+  [443] = {.lex_state = 357},
+  [444] = {.lex_state = 357},
   [445] = {.lex_state = 357},
-  [446] = {.lex_state = 38},
+  [446] = {.lex_state = 357},
   [447] = {.lex_state = 357},
+  [448] = {.lex_state = 357},
+  [449] = {.lex_state = 357},
+  [450] = {.lex_state = 357},
+  [451] = {.lex_state = 357},
+  [452] = {.lex_state = 39},
+  [453] = {.lex_state = 39},
+  [454] = {.lex_state = 39},
+  [455] = {.lex_state = 357},
+  [456] = {.lex_state = 9},
+  [457] = {.lex_state = 357},
+  [458] = {.lex_state = 9},
+  [459] = {.lex_state = 357},
+  [460] = {.lex_state = 39},
+  [461] = {.lex_state = 39},
+  [462] = {.lex_state = 39},
+  [463] = {.lex_state = 357},
+  [464] = {.lex_state = 357},
+  [465] = {.lex_state = 357},
+  [466] = {.lex_state = 39},
+  [467] = {.lex_state = 39},
+  [468] = {.lex_state = 39},
+  [469] = {.lex_state = 357},
+  [470] = {.lex_state = 39},
+  [471] = {.lex_state = 357},
 };
 
 static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
@@ -6269,16 +6378,16 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [sym_comment] = ACTIONS(3),
   },
   [STATE(1)] = {
-    [sym_source_file] = STATE(353),
-    [sym_section] = STATE(28),
-    [sym_comments_section] = STATE(100),
-    [sym_settings_section] = STATE(100),
-    [sym_variables_section] = STATE(100),
-    [sym_keywords_section] = STATE(100),
-    [sym_test_cases_section] = STATE(100),
-    [sym__empty_line] = STATE(18),
-    [aux_sym_source_file_repeat1] = STATE(18),
-    [aux_sym_source_file_repeat2] = STATE(28),
+    [sym_source_file] = STATE(457),
+    [sym_section] = STATE(27),
+    [sym_comments_section] = STATE(93),
+    [sym_settings_section] = STATE(93),
+    [sym_variables_section] = STATE(93),
+    [sym_keywords_section] = STATE(93),
+    [sym_test_cases_section] = STATE(93),
+    [sym__empty_line] = STATE(16),
+    [aux_sym_source_file_repeat1] = STATE(16),
+    [aux_sym_source_file_repeat2] = STATE(27),
     [ts_builtin_sym_end] = ACTIONS(5),
     [aux_sym_comments_section_token1] = ACTIONS(7),
     [aux_sym_settings_section_token1] = ACTIONS(9),
@@ -6300,9 +6409,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym__line_break,
     ACTIONS(29), 1,
       aux_sym__empty_line_token1,
-    STATE(120), 1,
+    STATE(103), 1,
       sym_setting_name,
-    STATE(6), 3,
+    STATE(4), 3,
       sym_setting_statement,
       sym__empty_line,
       aux_sym_settings_section_repeat1,
@@ -6342,9 +6451,9 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__empty_line_token1,
     ACTIONS(33), 1,
       sym__line_break,
-    STATE(120), 1,
+    STATE(103), 1,
       sym_setting_name,
-    STATE(4), 3,
+    STATE(5), 3,
       sym_setting_statement,
       sym__empty_line,
       aux_sym_settings_section_repeat1,
@@ -6384,13 +6493,13 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym__empty_line_token1,
     ACTIONS(35), 1,
       sym__line_break,
-    STATE(120), 1,
+    STATE(103), 1,
       sym_setting_name,
-    STATE(5), 3,
+    STATE(6), 3,
       sym_setting_statement,
       sym__empty_line,
       aux_sym_settings_section_repeat1,
-    ACTIONS(21), 7,
+    ACTIONS(31), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -6422,13 +6531,13 @@ static const uint16_t ts_small_parse_table[] = {
   [147] = 7,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(42), 1,
-      sym__line_break,
-    ACTIONS(45), 1,
+    ACTIONS(29), 1,
       aux_sym__empty_line_token1,
-    STATE(120), 1,
+    ACTIONS(35), 1,
+      sym__line_break,
+    STATE(103), 1,
       sym_setting_name,
-    STATE(5), 3,
+    STATE(6), 3,
       sym_setting_statement,
       sym__empty_line,
       aux_sym_settings_section_repeat1,
@@ -6440,7 +6549,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-    ACTIONS(39), 20,
+    ACTIONS(23), 20,
       aux_sym_setting_name_token1,
       aux_sym_setting_name_token2,
       aux_sym_setting_name_token3,
@@ -6464,17 +6573,17 @@ static const uint16_t ts_small_parse_table[] = {
   [196] = 7,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(29), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(35), 1,
+    ACTIONS(44), 1,
       sym__line_break,
-    STATE(120), 1,
+    ACTIONS(47), 1,
+      aux_sym__empty_line_token1,
+    STATE(103), 1,
       sym_setting_name,
-    STATE(5), 3,
+    STATE(6), 3,
       sym_setting_statement,
       sym__empty_line,
       aux_sym_settings_section_repeat1,
-    ACTIONS(48), 7,
+    ACTIONS(39), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -6482,7 +6591,7 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-    ACTIONS(23), 20,
+    ACTIONS(41), 20,
       aux_sym_setting_name_token1,
       aux_sym_setting_name_token2,
       aux_sym_setting_name_token3,
@@ -6599,14 +6708,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WHILE,
     ACTIONS(78), 1,
       anon_sym_FOR,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(344), 1,
+    STATE(356), 1,
       sym_statement,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6638,14 +6747,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_ELSEIF,
     ACTIONS(86), 1,
       anon_sym_ELSE,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(344), 1,
+    STATE(356), 1,
       sym_statement,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6673,15 +6782,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_FOR,
     ACTIONS(88), 1,
       anon_sym_LBRACK,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(335), 2,
+    STATE(366), 2,
       sym_keyword_setting,
       sym_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6709,15 +6818,15 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_FOR,
     ACTIONS(90), 1,
       anon_sym_LBRACK,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(349), 2,
+    STATE(382), 2,
       sym_test_case_setting,
       sym_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6745,14 +6854,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_FOR,
     ACTIONS(92), 1,
       anon_sym_END,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(344), 1,
+    STATE(356), 1,
       sym_statement,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6780,14 +6889,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_FOR,
     ACTIONS(94), 1,
       sym_ellipses,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(344), 1,
+    STATE(356), 1,
       sym_statement,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6813,14 +6922,14 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_WHILE,
     ACTIONS(78), 1,
       anon_sym_FOR,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(344), 1,
+    STATE(356), 1,
       sym_statement,
     ACTIONS(80), 2,
       sym_continue_statement,
       sym_break_statement,
-    STATE(334), 8,
+    STATE(364), 8,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
@@ -6829,65 +6938,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_try_statement,
       sym_while_statement,
       sym_for_statement,
-  [672] = 9,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(29), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(98), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(100), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(102), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(104), 1,
-      sym__line_break,
-    STATE(19), 3,
-      sym_variable_definition,
-      sym__empty_line,
-      aux_sym_variables_section_repeat1,
-    STATE(81), 3,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-    ACTIONS(96), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [710] = 9,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(29), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(98), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(100), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(102), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(108), 1,
-      sym__line_break,
-    STATE(20), 3,
-      sym_variable_definition,
-      sym__empty_line,
-      aux_sym_variables_section_repeat1,
-    STATE(81), 3,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-    ACTIONS(106), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [748] = 11,
+  [672] = 11,
     ACTIONS(7), 1,
       aux_sym_comments_section_token1,
     ACTIONS(9), 1,
@@ -6898,48 +6949,106 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
     ACTIONS(19), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(110), 1,
+    ACTIONS(96), 1,
       ts_builtin_sym_end,
     ACTIONS(15), 2,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-    ACTIONS(112), 2,
+    ACTIONS(98), 2,
       sym_comment,
       sym__line_break,
-    STATE(33), 2,
+    STATE(38), 2,
       sym_section,
       aux_sym_source_file_repeat2,
-    STATE(54), 2,
+    STATE(43), 2,
       sym__empty_line,
       aux_sym_source_file_repeat1,
-    STATE(100), 5,
+    STATE(93), 5,
       sym_comments_section,
       sym_settings_section,
       sym_variables_section,
       sym_keywords_section,
       sym_test_cases_section,
+  [714] = 9,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(102), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(105), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(108), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(111), 1,
+      sym__line_break,
+    ACTIONS(114), 1,
+      aux_sym__empty_line_token1,
+    STATE(17), 3,
+      sym_variable_definition,
+      sym__empty_line,
+      aux_sym_variables_section_repeat1,
+    STATE(83), 3,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+    ACTIONS(100), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [752] = 9,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(29), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(119), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(121), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(123), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(125), 1,
+      sym__line_break,
+    STATE(17), 3,
+      sym_variable_definition,
+      sym__empty_line,
+      aux_sym_variables_section_repeat1,
+    STATE(83), 3,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+    ACTIONS(117), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
   [790] = 9,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(29), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(98), 1,
+    ACTIONS(119), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(100), 1,
+    ACTIONS(121), 1,
       anon_sym_AT_LBRACE,
-    ACTIONS(102), 1,
+    ACTIONS(123), 1,
       anon_sym_AMP_LBRACE,
-    ACTIONS(114), 1,
+    ACTIONS(129), 1,
       sym__line_break,
-    STATE(21), 3,
+    STATE(20), 3,
       sym_variable_definition,
       sym__empty_line,
       aux_sym_variables_section_repeat1,
-    STATE(81), 3,
+    STATE(83), 3,
       sym_scalar_variable,
       sym_list_variable,
       sym_dictionary_variable,
-    ACTIONS(106), 7,
+    ACTIONS(127), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -6952,23 +7061,23 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
     ACTIONS(29), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(98), 1,
+    ACTIONS(119), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(100), 1,
+    ACTIONS(121), 1,
       anon_sym_AT_LBRACE,
-    ACTIONS(102), 1,
+    ACTIONS(123), 1,
       anon_sym_AMP_LBRACE,
-    ACTIONS(114), 1,
+    ACTIONS(125), 1,
       sym__line_break,
-    STATE(21), 3,
+    STATE(17), 3,
       sym_variable_definition,
       sym__empty_line,
       aux_sym_variables_section_repeat1,
-    STATE(81), 3,
+    STATE(83), 3,
       sym_scalar_variable,
       sym_list_variable,
       sym_dictionary_variable,
-    ACTIONS(116), 7,
+    ACTIONS(131), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -6979,25 +7088,25 @@ static const uint16_t ts_small_parse_table[] = {
   [866] = 9,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(120), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(123), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(126), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(129), 1,
-      sym__line_break,
-    ACTIONS(132), 1,
+    ACTIONS(29), 1,
       aux_sym__empty_line_token1,
-    STATE(21), 3,
+    ACTIONS(119), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(121), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(123), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(133), 1,
+      sym__line_break,
+    STATE(18), 3,
       sym_variable_definition,
       sym__empty_line,
       aux_sym_variables_section_repeat1,
-    STATE(81), 3,
+    STATE(83), 3,
       sym_scalar_variable,
       sym_list_variable,
       sym_dictionary_variable,
-    ACTIONS(118), 7,
+    ACTIONS(131), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -7016,11 +7125,11 @@ static const uint16_t ts_small_parse_table[] = {
       sym__line_break,
     ACTIONS(143), 1,
       aux_sym__empty_line_token1,
-    STATE(87), 1,
+    STATE(86), 1,
       sym_name_chunk,
-    STATE(272), 1,
+    STATE(316), 1,
       sym_keyword_name,
-    STATE(25), 3,
+    STATE(23), 3,
       sym_keyword_definition,
       sym__empty_line,
       aux_sym_keywords_section_repeat1,
@@ -7034,19 +7143,19 @@ static const uint16_t ts_small_parse_table[] = {
   [939] = 9,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(139), 1,
-      sym__text_chunk,
-    ACTIONS(143), 1,
-      aux_sym__empty_line_token1,
     ACTIONS(145), 1,
       ts_builtin_sym_end,
     ACTIONS(149), 1,
+      sym__text_chunk,
+    ACTIONS(152), 1,
       sym__line_break,
-    STATE(87), 1,
+    ACTIONS(155), 1,
+      aux_sym__empty_line_token1,
+    STATE(86), 1,
       sym_name_chunk,
-    STATE(272), 1,
+    STATE(316), 1,
       sym_keyword_name,
-    STATE(22), 3,
+    STATE(23), 3,
       sym_keyword_definition,
       sym__empty_line,
       aux_sym_keywords_section_repeat1,
@@ -7060,23 +7169,23 @@ static const uint16_t ts_small_parse_table[] = {
   [974] = 9,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(135), 1,
-      ts_builtin_sym_end,
     ACTIONS(139), 1,
       sym__text_chunk,
     ACTIONS(143), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(151), 1,
+    ACTIONS(158), 1,
+      ts_builtin_sym_end,
+    ACTIONS(162), 1,
       sym__line_break,
-    STATE(87), 1,
+    STATE(86), 1,
       sym_name_chunk,
-    STATE(272), 1,
+    STATE(316), 1,
       sym_keyword_name,
-    STATE(26), 3,
+    STATE(25), 3,
       sym_keyword_definition,
       sym__empty_line,
       aux_sym_keywords_section_repeat1,
-    ACTIONS(137), 6,
+    ACTIONS(160), 6,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
@@ -7086,23 +7195,23 @@ static const uint16_t ts_small_parse_table[] = {
   [1009] = 9,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(153), 1,
-      ts_builtin_sym_end,
-    ACTIONS(157), 1,
+    ACTIONS(139), 1,
       sym__text_chunk,
-    ACTIONS(160), 1,
+    ACTIONS(141), 1,
       sym__line_break,
-    ACTIONS(163), 1,
+    ACTIONS(143), 1,
       aux_sym__empty_line_token1,
-    STATE(87), 1,
+    ACTIONS(164), 1,
+      ts_builtin_sym_end,
+    STATE(86), 1,
       sym_name_chunk,
-    STATE(272), 1,
+    STATE(316), 1,
       sym_keyword_name,
-    STATE(25), 3,
+    STATE(23), 3,
       sym_keyword_definition,
       sym__empty_line,
       aux_sym_keywords_section_repeat1,
-    ACTIONS(155), 6,
+    ACTIONS(166), 6,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
@@ -7114,28 +7223,53 @@ static const uint16_t ts_small_parse_table[] = {
       sym_comment,
     ACTIONS(139), 1,
       sym__text_chunk,
-    ACTIONS(141), 1,
-      sym__line_break,
     ACTIONS(143), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(166), 1,
+    ACTIONS(164), 1,
       ts_builtin_sym_end,
-    STATE(87), 1,
+    ACTIONS(168), 1,
+      sym__line_break,
+    STATE(86), 1,
       sym_name_chunk,
-    STATE(272), 1,
+    STATE(316), 1,
       sym_keyword_name,
-    STATE(25), 3,
+    STATE(22), 3,
       sym_keyword_definition,
       sym__empty_line,
       aux_sym_keywords_section_repeat1,
-    ACTIONS(168), 6,
+    ACTIONS(166), 6,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-  [1079] = 8,
+  [1079] = 9,
+    ACTIONS(7), 1,
+      aux_sym_comments_section_token1,
+    ACTIONS(9), 1,
+      aux_sym_settings_section_token1,
+    ACTIONS(11), 1,
+      aux_sym_variables_section_token1,
+    ACTIONS(13), 1,
+      aux_sym_keywords_section_token1,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(96), 1,
+      ts_builtin_sym_end,
+    ACTIONS(15), 2,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+    STATE(30), 2,
+      sym_section,
+      aux_sym_source_file_repeat2,
+    STATE(93), 5,
+      sym_comments_section,
+      sym_settings_section,
+      sym_variables_section,
+      sym_keywords_section,
+      sym_test_cases_section,
+  [1113] = 8,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(143), 1,
@@ -7146,9 +7280,9 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text_chunk,
     ACTIONS(176), 1,
       sym__line_break,
-    STATE(185), 1,
+    STATE(189), 1,
       sym_text_chunk,
-    STATE(34), 3,
+    STATE(29), 3,
       sym_test_case_definition,
       sym__empty_line,
       aux_sym_test_cases_section_repeat1,
@@ -7159,45 +7293,20 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-  [1111] = 9,
-    ACTIONS(7), 1,
-      aux_sym_comments_section_token1,
-    ACTIONS(9), 1,
-      aux_sym_settings_section_token1,
-    ACTIONS(11), 1,
-      aux_sym_variables_section_token1,
-    ACTIONS(13), 1,
-      aux_sym_keywords_section_token1,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(110), 1,
-      ts_builtin_sym_end,
-    ACTIONS(15), 2,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-    STATE(38), 2,
-      sym_section,
-      aux_sym_source_file_repeat2,
-    STATE(100), 5,
-      sym_comments_section,
-      sym_settings_section,
-      sym_variables_section,
-      sym_keywords_section,
-      sym_test_cases_section,
   [1145] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(143), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(174), 1,
-      sym__text_chunk,
     ACTIONS(178), 1,
       ts_builtin_sym_end,
     ACTIONS(182), 1,
+      sym__text_chunk,
+    ACTIONS(185), 1,
       sym__line_break,
-    STATE(185), 1,
+    ACTIONS(188), 1,
+      aux_sym__empty_line_token1,
+    STATE(189), 1,
       sym_text_chunk,
-    STATE(30), 3,
+    STATE(29), 3,
       sym_test_case_definition,
       sym__empty_line,
       aux_sym_test_cases_section_repeat1,
@@ -7208,47 +7317,96 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-  [1177] = 8,
+  [1177] = 9,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(191), 1,
+      ts_builtin_sym_end,
+    ACTIONS(193), 1,
+      aux_sym_comments_section_token1,
+    ACTIONS(196), 1,
+      aux_sym_settings_section_token1,
+    ACTIONS(199), 1,
+      aux_sym_variables_section_token1,
+    ACTIONS(202), 1,
+      aux_sym_keywords_section_token1,
+    ACTIONS(205), 2,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+    STATE(30), 2,
+      sym_section,
+      aux_sym_source_file_repeat2,
+    STATE(93), 5,
+      sym_comments_section,
+      sym_settings_section,
+      sym_variables_section,
+      sym_keywords_section,
+      sym_test_cases_section,
+  [1211] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(184), 1,
+    ACTIONS(208), 1,
       ts_builtin_sym_end,
-    ACTIONS(188), 1,
-      sym__text_chunk,
-    ACTIONS(191), 1,
+    ACTIONS(212), 1,
+      sym__separator,
+    ACTIONS(214), 1,
       sym__line_break,
-    ACTIONS(194), 1,
+    ACTIONS(216), 1,
       aux_sym__empty_line_token1,
-    STATE(185), 1,
-      sym_text_chunk,
-    STATE(30), 3,
-      sym_test_case_definition,
+    STATE(11), 1,
+      sym__indentation,
+    STATE(34), 2,
       sym__empty_line,
-      aux_sym_test_cases_section_repeat1,
-    ACTIONS(186), 6,
+      aux_sym_keyword_definition_body_repeat1,
+    ACTIONS(210), 7,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-  [1209] = 8,
+      sym__text_chunk,
+  [1243] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(197), 1,
+    ACTIONS(216), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(218), 1,
       ts_builtin_sym_end,
-    ACTIONS(201), 1,
+    ACTIONS(222), 1,
       sym__separator,
-    ACTIONS(203), 1,
+    ACTIONS(224), 1,
       sym__line_break,
-    ACTIONS(205), 1,
+    STATE(12), 1,
+      sym__indentation,
+    STATE(33), 2,
+      sym__empty_line,
+      aux_sym_test_case_definition_body_repeat1,
+    ACTIONS(220), 7,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+      sym__text_chunk,
+  [1275] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(226), 1,
+      ts_builtin_sym_end,
+    ACTIONS(230), 1,
+      sym__separator,
+    ACTIONS(233), 1,
+      sym__line_break,
+    ACTIONS(236), 1,
       aux_sym__empty_line_token1,
     STATE(12), 1,
       sym__indentation,
-    STATE(35), 2,
+    STATE(33), 2,
       sym__empty_line,
       aux_sym_test_case_definition_body_repeat1,
-    ACTIONS(199), 7,
+    ACTIONS(228), 7,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
@@ -7256,23 +7414,23 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
       sym__text_chunk,
-  [1241] = 8,
+  [1307] = 8,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(205), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(207), 1,
+    ACTIONS(239), 1,
       ts_builtin_sym_end,
-    ACTIONS(211), 1,
+    ACTIONS(243), 1,
       sym__separator,
-    ACTIONS(213), 1,
+    ACTIONS(246), 1,
       sym__line_break,
+    ACTIONS(249), 1,
+      aux_sym__empty_line_token1,
     STATE(11), 1,
       sym__indentation,
-    STATE(36), 2,
+    STATE(34), 2,
       sym__empty_line,
       aux_sym_keyword_definition_body_repeat1,
-    ACTIONS(209), 7,
+    ACTIONS(241), 7,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
@@ -7280,7 +7438,79 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
       sym__text_chunk,
-  [1273] = 9,
+  [1339] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(143), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(174), 1,
+      sym__text_chunk,
+    ACTIONS(252), 1,
+      ts_builtin_sym_end,
+    ACTIONS(256), 1,
+      sym__line_break,
+    STATE(189), 1,
+      sym_text_chunk,
+    STATE(28), 3,
+      sym_test_case_definition,
+      sym__empty_line,
+      aux_sym_test_cases_section_repeat1,
+    ACTIONS(254), 6,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1371] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(143), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(174), 1,
+      sym__text_chunk,
+    ACTIONS(176), 1,
+      sym__line_break,
+    ACTIONS(252), 1,
+      ts_builtin_sym_end,
+    STATE(189), 1,
+      sym_text_chunk,
+    STATE(29), 3,
+      sym_test_case_definition,
+      sym__empty_line,
+      aux_sym_test_cases_section_repeat1,
+    ACTIONS(254), 6,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1403] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(143), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(174), 1,
+      sym__text_chunk,
+    ACTIONS(258), 1,
+      ts_builtin_sym_end,
+    ACTIONS(262), 1,
+      sym__line_break,
+    STATE(189), 1,
+      sym_text_chunk,
+    STATE(36), 3,
+      sym_test_case_definition,
+      sym__empty_line,
+      aux_sym_test_cases_section_repeat1,
+    ACTIONS(260), 6,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1435] = 9,
     ACTIONS(7), 1,
       aux_sym_comments_section_token1,
     ACTIONS(9), 1,
@@ -7291,136 +7521,15 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(215), 1,
+    ACTIONS(264), 1,
       ts_builtin_sym_end,
     ACTIONS(15), 2,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
-    STATE(38), 2,
+    STATE(30), 2,
       sym_section,
       aux_sym_source_file_repeat2,
-    STATE(100), 5,
-      sym_comments_section,
-      sym_settings_section,
-      sym_variables_section,
-      sym_keywords_section,
-      sym_test_cases_section,
-  [1307] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(143), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(174), 1,
-      sym__text_chunk,
-    ACTIONS(182), 1,
-      sym__line_break,
-    ACTIONS(217), 1,
-      ts_builtin_sym_end,
-    STATE(185), 1,
-      sym_text_chunk,
-    STATE(30), 3,
-      sym_test_case_definition,
-      sym__empty_line,
-      aux_sym_test_cases_section_repeat1,
-    ACTIONS(219), 6,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1339] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(221), 1,
-      ts_builtin_sym_end,
-    ACTIONS(225), 1,
-      sym__separator,
-    ACTIONS(228), 1,
-      sym__line_break,
-    ACTIONS(231), 1,
-      aux_sym__empty_line_token1,
-    STATE(12), 1,
-      sym__indentation,
-    STATE(35), 2,
-      sym__empty_line,
-      aux_sym_test_case_definition_body_repeat1,
-    ACTIONS(223), 7,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-      sym__text_chunk,
-  [1371] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(234), 1,
-      ts_builtin_sym_end,
-    ACTIONS(238), 1,
-      sym__separator,
-    ACTIONS(241), 1,
-      sym__line_break,
-    ACTIONS(244), 1,
-      aux_sym__empty_line_token1,
-    STATE(11), 1,
-      sym__indentation,
-    STATE(36), 2,
-      sym__empty_line,
-      aux_sym_keyword_definition_body_repeat1,
-    ACTIONS(236), 7,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-      sym__text_chunk,
-  [1403] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(143), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(174), 1,
-      sym__text_chunk,
-    ACTIONS(217), 1,
-      ts_builtin_sym_end,
-    ACTIONS(247), 1,
-      sym__line_break,
-    STATE(185), 1,
-      sym_text_chunk,
-    STATE(29), 3,
-      sym_test_case_definition,
-      sym__empty_line,
-      aux_sym_test_cases_section_repeat1,
-    ACTIONS(219), 6,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1435] = 9,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(249), 1,
-      ts_builtin_sym_end,
-    ACTIONS(251), 1,
-      aux_sym_comments_section_token1,
-    ACTIONS(254), 1,
-      aux_sym_settings_section_token1,
-    ACTIONS(257), 1,
-      aux_sym_variables_section_token1,
-    ACTIONS(260), 1,
-      aux_sym_keywords_section_token1,
-    ACTIONS(263), 2,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-    STATE(38), 2,
-      sym_section,
-      aux_sym_source_file_repeat2,
-    STATE(100), 5,
+    STATE(93), 5,
       sym_comments_section,
       sym_settings_section,
       sym_variables_section,
@@ -7473,15 +7582,302 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE_LBRACE,
     ACTIONS(282), 1,
       sym__text_chunk,
-    STATE(250), 1,
+    STATE(272), 1,
       sym_argument,
-    STATE(60), 5,
+    STATE(63), 5,
       sym_scalar_variable,
       sym_list_variable,
       sym_dictionary_variable,
       sym_inline_python_expression,
       sym_text_chunk,
-  [1538] = 3,
+  [1538] = 4,
+    ACTIONS(19), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(98), 2,
+      sym_comment,
+      sym__line_break,
+    STATE(43), 2,
+      sym__empty_line,
+      aux_sym_source_file_repeat1,
+    ACTIONS(284), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1559] = 4,
+    ACTIONS(291), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(288), 2,
+      sym_comment,
+      sym__line_break,
+    STATE(43), 2,
+      sym__empty_line,
+      aux_sym_source_file_repeat1,
+    ACTIONS(286), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1580] = 4,
+    ACTIONS(19), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(296), 2,
+      sym_comment,
+      sym__line_break,
+    STATE(42), 2,
+      sym__empty_line,
+      aux_sym_source_file_repeat1,
+    ACTIONS(294), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1601] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(300), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(302), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(304), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(306), 1,
+      sym__text_chunk,
+    STATE(277), 1,
+      sym_argument,
+    STATE(71), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1630] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(274), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(276), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(278), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(280), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(282), 1,
+      sym__text_chunk,
+    STATE(278), 1,
+      sym_argument,
+    STATE(63), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1659] = 10,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(308), 1,
+      sym__separator,
+    ACTIONS(310), 1,
+      sym__line_break,
+    ACTIONS(312), 1,
+      aux_sym__empty_line_token1,
+    STATE(9), 1,
+      sym__indentation,
+    STATE(106), 1,
+      sym_block,
+    STATE(250), 1,
+      sym_else_statement,
+    STATE(279), 1,
+      sym_finally_statement,
+    STATE(107), 2,
+      sym__empty_line,
+      aux_sym_block_repeat1,
+    STATE(108), 2,
+      sym_except_statement,
+      aux_sym_try_statement_repeat1,
+  [1692] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(314), 1,
+      ts_builtin_sym_end,
+    ACTIONS(316), 10,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+      sym__text_chunk,
+      sym__separator,
+      sym__line_break,
+      aux_sym__empty_line_token1,
+  [1711] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(318), 1,
+      ts_builtin_sym_end,
+    ACTIONS(320), 10,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+      sym__text_chunk,
+      sym__separator,
+      sym__line_break,
+      aux_sym__empty_line_token1,
+  [1730] = 4,
+    ACTIONS(19), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(322), 2,
+      sym_comment,
+      sym__line_break,
+    STATE(51), 2,
+      sym__empty_line,
+      aux_sym_source_file_repeat1,
+    ACTIONS(284), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1751] = 4,
+    ACTIONS(19), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(98), 2,
+      sym_comment,
+      sym__line_break,
+    STATE(43), 2,
+      sym__empty_line,
+      aux_sym_source_file_repeat1,
+    ACTIONS(324), 7,
+      ts_builtin_sym_end,
+      aux_sym_comments_section_token1,
+      aux_sym_settings_section_token1,
+      aux_sym_variables_section_token1,
+      aux_sym_keywords_section_token1,
+      aux_sym_test_cases_section_token1,
+      aux_sym_test_cases_section_token2,
+  [1772] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(274), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(276), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(278), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(280), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(282), 1,
+      sym__text_chunk,
+    STATE(276), 1,
+      sym_argument,
+    STATE(63), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1801] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(274), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(276), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(278), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(280), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(282), 1,
+      sym__text_chunk,
+    STATE(263), 1,
+      sym_argument,
+    STATE(63), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1830] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(300), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(302), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(304), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(306), 1,
+      sym__text_chunk,
+    STATE(395), 1,
+      sym_argument,
+    STATE(71), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1859] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(326), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(328), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(330), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(332), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(334), 1,
+      sym__text_chunk,
+    STATE(414), 1,
+      sym_argument,
+    STATE(72), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1888] = 8,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(300), 1,
+      anon_sym_AT_LBRACE,
+    ACTIONS(302), 1,
+      anon_sym_AMP_LBRACE,
+    ACTIONS(304), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(306), 1,
+      sym__text_chunk,
+    STATE(437), 1,
+      sym_argument,
+    STATE(71), 5,
+      sym_scalar_variable,
+      sym_list_variable,
+      sym_dictionary_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [1917] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(50), 1,
@@ -7497,293 +7893,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym__separator,
       sym__line_break,
       aux_sym__empty_line_token1,
-  [1557] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(284), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(286), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(288), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(290), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
-      sym__text_chunk,
-    STATE(231), 1,
-      sym_argument,
-    STATE(71), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1586] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(274), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(276), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(278), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(280), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(282), 1,
-      sym__text_chunk,
-    STATE(233), 1,
-      sym_argument,
-    STATE(60), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1615] = 10,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(294), 1,
-      sym__separator,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    STATE(9), 1,
-      sym__indentation,
-    STATE(117), 1,
-      sym_block,
-    STATE(215), 1,
-      sym_else_statement,
-    STATE(237), 1,
-      sym_finally_statement,
-    STATE(132), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-    STATE(135), 2,
-      sym_except_statement,
-      aux_sym_try_statement_repeat1,
-  [1648] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(300), 1,
-      ts_builtin_sym_end,
-    ACTIONS(302), 10,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-      sym__text_chunk,
-      sym__separator,
-      sym__line_break,
-      aux_sym__empty_line_token1,
-  [1667] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(304), 1,
-      ts_builtin_sym_end,
-    ACTIONS(306), 10,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-      sym__text_chunk,
-      sym__separator,
-      sym__line_break,
-      aux_sym__empty_line_token1,
-  [1686] = 4,
-    ACTIONS(19), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(112), 2,
-      sym_comment,
-      sym__line_break,
-    STATE(54), 2,
-      sym__empty_line,
-      aux_sym_source_file_repeat1,
-    ACTIONS(308), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1707] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(274), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(276), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(278), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(280), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(282), 1,
-      sym__text_chunk,
-    STATE(232), 1,
-      sym_argument,
-    STATE(60), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1736] = 4,
-    ACTIONS(19), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(312), 2,
-      sym_comment,
-      sym__line_break,
-    STATE(48), 2,
-      sym__empty_line,
-      aux_sym_source_file_repeat1,
-    ACTIONS(310), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1757] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(274), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(276), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(278), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(280), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(282), 1,
-      sym__text_chunk,
-    STATE(241), 1,
-      sym_argument,
-    STATE(60), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1786] = 4,
-    ACTIONS(19), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(112), 2,
-      sym_comment,
-      sym__line_break,
-    STATE(54), 2,
-      sym__empty_line,
-      aux_sym_source_file_repeat1,
-    ACTIONS(310), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1807] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(284), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(286), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(288), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(290), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
-      sym__text_chunk,
-    STATE(411), 1,
-      sym_argument,
-    STATE(71), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1836] = 4,
-    ACTIONS(319), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(316), 2,
-      sym_comment,
-      sym__line_break,
-    STATE(54), 2,
-      sym__empty_line,
-      aux_sym_source_file_repeat1,
-    ACTIONS(314), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
-  [1857] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(322), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(324), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(326), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(328), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(330), 1,
-      sym__text_chunk,
-    STATE(425), 1,
-      sym_argument,
-    STATE(72), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1886] = 8,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(284), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(286), 1,
-      anon_sym_AT_LBRACE,
-    ACTIONS(288), 1,
-      anon_sym_AMP_LBRACE,
-    ACTIONS(290), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
-      sym__text_chunk,
-    STATE(439), 1,
-      sym_argument,
-    STATE(71), 5,
-      sym_scalar_variable,
-      sym_list_variable,
-      sym_dictionary_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [1915] = 4,
-    ACTIONS(19), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(334), 2,
-      sym_comment,
-      sym__line_break,
-    STATE(52), 2,
-      sym__empty_line,
-      aux_sym_source_file_repeat1,
-    ACTIONS(332), 7,
-      ts_builtin_sym_end,
-      aux_sym_comments_section_token1,
-      aux_sym_settings_section_token1,
-      aux_sym_variables_section_token1,
-      aux_sym_keywords_section_token1,
-      aux_sym_test_cases_section_token1,
-      aux_sym_test_cases_section_token2,
   [1936] = 8,
     ACTIONS(3), 1,
       sym_comment,
@@ -7797,9 +7906,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE_LBRACE,
     ACTIONS(282), 1,
       sym__text_chunk,
-    STATE(231), 1,
+    STATE(277), 1,
       sym_argument,
-    STATE(60), 5,
+    STATE(63), 5,
       sym_scalar_variable,
       sym_list_variable,
       sym_dictionary_variable,
@@ -7808,23 +7917,23 @@ static const uint16_t ts_small_parse_table[] = {
   [1965] = 10,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(296), 1,
+    ACTIONS(310), 1,
       sym__line_break,
-    ACTIONS(298), 1,
+    ACTIONS(312), 1,
       aux_sym__empty_line_token1,
     ACTIONS(336), 1,
       sym__separator,
     STATE(10), 1,
       sym__indentation,
-    STATE(140), 1,
+    STATE(145), 1,
       aux_sym_if_statement_repeat1,
-    STATE(143), 1,
+    STATE(178), 1,
       sym_block,
-    STATE(275), 1,
+    STATE(298), 1,
       sym_else_statement,
-    STATE(369), 1,
+    STATE(379), 1,
       sym_elseif_statement,
-    STATE(132), 2,
+    STATE(107), 2,
       sym__empty_line,
       aux_sym_block_repeat1,
   [1997] = 7,
@@ -7841,7 +7950,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(340), 2,
       sym__separator,
       sym__line_break,
-    STATE(63), 4,
+    STATE(65), 4,
       sym_scalar_variable,
       sym_inline_python_expression,
       sym_text_chunk,
@@ -7874,9 +7983,9 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_INENUMERATE,
     ACTIONS(354), 1,
       anon_sym_INZIP,
-    STATE(366), 1,
+    STATE(333), 1,
       sym_scalar_variable,
-    STATE(357), 4,
+    STATE(367), 4,
       sym__for_in,
       sym__for_in_range,
       sym__for_in_enumerate,
@@ -7895,7 +8004,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(356), 2,
       sym__separator,
       sym__line_break,
-    STATE(67), 4,
+    STATE(60), 4,
       sym_scalar_variable,
       sym_inline_python_expression,
       sym_text_chunk,
@@ -7915,7 +8024,26 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text_chunk,
       sym__line_break,
       aux_sym__empty_line_token1,
-  [2113] = 3,
+  [2113] = 7,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(362), 1,
+      anon_sym_SPACE,
+    ACTIONS(365), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(368), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(371), 1,
+      sym__text_chunk,
+    ACTIONS(374), 2,
+      sym__separator,
+      sym__line_break,
+    STATE(65), 4,
+      sym_scalar_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+      aux_sym_argument_repeat1,
+  [2139] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(50), 1,
@@ -7930,12 +8058,12 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text_chunk,
       sym__line_break,
       aux_sym__empty_line_token1,
-  [2131] = 3,
+  [2157] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(362), 1,
+    ACTIONS(376), 1,
       ts_builtin_sym_end,
-    ACTIONS(364), 9,
+    ACTIONS(378), 9,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
       aux_sym_variables_section_token1,
@@ -7945,25 +8073,6 @@ static const uint16_t ts_small_parse_table[] = {
       sym__text_chunk,
       sym__line_break,
       aux_sym__empty_line_token1,
-  [2149] = 7,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(366), 1,
-      anon_sym_SPACE,
-    ACTIONS(369), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(372), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(375), 1,
-      sym__text_chunk,
-    ACTIONS(378), 2,
-      sym__separator,
-      sym__line_break,
-    STATE(67), 4,
-      sym_scalar_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-      aux_sym_argument_repeat1,
   [2175] = 2,
     ACTIONS(52), 1,
       aux_sym__empty_line_token1,
@@ -7980,13 +8089,13 @@ static const uint16_t ts_small_parse_table[] = {
   [2190] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(284), 1,
+    ACTIONS(298), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(290), 1,
+    ACTIONS(304), 1,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
+    ACTIONS(306), 1,
       sym__text_chunk,
-    ACTIONS(356), 1,
+    ACTIONS(340), 1,
       sym__line_break,
     ACTIONS(380), 1,
       anon_sym_SPACE,
@@ -7998,7 +8107,7 @@ static const uint16_t ts_small_parse_table[] = {
   [2215] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(378), 1,
+    ACTIONS(374), 1,
       sym__line_break,
     ACTIONS(382), 1,
       anon_sym_SPACE,
@@ -8016,13 +8125,13 @@ static const uint16_t ts_small_parse_table[] = {
   [2240] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(284), 1,
+    ACTIONS(298), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(290), 1,
+    ACTIONS(304), 1,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
+    ACTIONS(306), 1,
       sym__text_chunk,
-    ACTIONS(340), 1,
+    ACTIONS(356), 1,
       sym__line_break,
     ACTIONS(380), 1,
       anon_sym_SPACE,
@@ -8034,13 +8143,13 @@ static const uint16_t ts_small_parse_table[] = {
   [2265] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(322), 1,
+    ACTIONS(326), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(328), 1,
+    ACTIONS(332), 1,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(330), 1,
+    ACTIONS(334), 1,
       sym__text_chunk,
-    ACTIONS(340), 1,
+    ACTIONS(356), 1,
       sym__separator,
     ACTIONS(394), 1,
       anon_sym_SPACE,
@@ -8052,13 +8161,13 @@ static const uint16_t ts_small_parse_table[] = {
   [2290] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(322), 1,
+    ACTIONS(326), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(328), 1,
+    ACTIONS(332), 1,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(330), 1,
+    ACTIONS(334), 1,
       sym__text_chunk,
-    ACTIONS(356), 1,
+    ACTIONS(340), 1,
       sym__separator,
     ACTIONS(394), 1,
       anon_sym_SPACE,
@@ -8070,7 +8179,7 @@ static const uint16_t ts_small_parse_table[] = {
   [2315] = 7,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(378), 1,
+    ACTIONS(374), 1,
       sym__separator,
     ACTIONS(396), 1,
       anon_sym_SPACE,
@@ -8085,169 +8194,86 @@ static const uint16_t ts_small_parse_table[] = {
       sym_inline_python_expression,
       sym_text_chunk,
       aux_sym_argument_repeat1,
-  [2340] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(412), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(253), 1,
-      sym_arguments,
-    ACTIONS(408), 2,
-      anon_sym_EQ,
-      anon_sym_EQ2,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [2364] = 6,
+  [2340] = 6,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(415), 1,
+    ACTIONS(408), 1,
       anon_sym_SPACE,
-    ACTIONS(417), 1,
+    ACTIONS(411), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(419), 1,
+    ACTIONS(414), 1,
       sym__text_chunk,
-    ACTIONS(421), 2,
+    ACTIONS(417), 2,
       sym__separator,
       sym__line_break,
-    STATE(83), 3,
+    STATE(75), 3,
       sym_name_chunk,
       sym_scalar_variable,
       aux_sym_keyword_name_repeat1,
-  [2386] = 4,
+  [2362] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(425), 1,
+    ACTIONS(421), 1,
       anon_sym_SPACE,
-    STATE(255), 1,
-      sym_keyword_setting_name,
-    ACTIONS(423), 6,
-      aux_sym_setting_name_token5,
-      aux_sym_keyword_setting_name_token1,
-      aux_sym_keyword_setting_name_token2,
-      aux_sym_keyword_setting_name_token3,
-      aux_sym_keyword_setting_name_token4,
-      aux_sym_keyword_setting_name_token5,
-  [2404] = 7,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(62), 1,
-      aux_sym_keyword_token1,
-    ACTIONS(427), 1,
-      anon_sym_RETURN,
-    ACTIONS(429), 1,
-      anon_sym_DOLLAR_LBRACE,
-    STATE(124), 1,
-      sym_keyword,
-    STATE(205), 1,
-      sym_inline_statement,
-    STATE(273), 3,
-      sym_return_statement,
-      sym_variable_assignment,
-      sym_keyword_invocation,
-  [2428] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(433), 1,
-      anon_sym_SPACE,
-    STATE(274), 1,
+    STATE(273), 1,
       sym_test_case_setting_name,
-    ACTIONS(431), 6,
+    ACTIONS(419), 6,
       aux_sym_setting_name_token5,
       aux_sym_keyword_setting_name_token1,
       aux_sym_keyword_setting_name_token4,
       aux_sym_keyword_setting_name_token5,
       aux_sym_test_case_setting_name_token1,
       aux_sym_test_case_setting_name_token2,
-  [2446] = 6,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(415), 1,
-      anon_sym_SPACE,
-    ACTIONS(417), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(419), 1,
-      sym__text_chunk,
-    ACTIONS(435), 2,
-      sym__separator,
-      sym__line_break,
-    STATE(88), 3,
-      sym_name_chunk,
-      sym_scalar_variable,
-      aux_sym_keyword_name_repeat1,
-  [2468] = 7,
+  [2380] = 8,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(310), 1,
       sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(447), 1,
-      sym_arguments,
-    ACTIONS(437), 2,
-      anon_sym_EQ,
-      anon_sym_EQ2,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [2492] = 8,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
+    ACTIONS(312), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(441), 1,
+    ACTIONS(423), 1,
       sym_ellipses,
-    ACTIONS(443), 1,
+    ACTIONS(425), 1,
       sym__separator,
     STATE(14), 1,
       sym__indentation,
-    STATE(328), 1,
+    STATE(372), 1,
       sym_block,
-    STATE(132), 2,
+    STATE(107), 2,
       sym__empty_line,
       aux_sym_block_repeat1,
-  [2518] = 6,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(446), 1,
-      anon_sym_SPACE,
-    ACTIONS(449), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(452), 1,
-      sym__text_chunk,
-    ACTIONS(455), 2,
-      sym__separator,
-      sym__line_break,
-    STATE(83), 3,
-      sym_name_chunk,
-      sym_scalar_variable,
-      aux_sym_keyword_name_repeat1,
-  [2540] = 7,
+  [2406] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(459), 1,
+    ACTIONS(430), 1,
+      anon_sym_SPACE,
+    STATE(289), 1,
+      sym_keyword_setting_name,
+    ACTIONS(428), 6,
+      aux_sym_setting_name_token5,
+      aux_sym_keyword_setting_name_token1,
+      aux_sym_keyword_setting_name_token2,
+      aux_sym_keyword_setting_name_token3,
+      aux_sym_keyword_setting_name_token4,
+      aux_sym_keyword_setting_name_token5,
+  [2424] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(462), 1,
+    ACTIONS(436), 1,
       sym__line_break,
-    STATE(172), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(253), 1,
+    STATE(285), 1,
       sym_arguments,
-    ACTIONS(457), 2,
+    ACTIONS(432), 2,
       anon_sym_EQ,
       anon_sym_EQ2,
-    STATE(192), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [2564] = 7,
+  [2448] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(58), 1,
@@ -8256,235 +8282,214 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE,
     ACTIONS(62), 1,
       aux_sym_keyword_token1,
-    STATE(110), 1,
+    STATE(123), 1,
       sym_keyword,
-    STATE(426), 1,
+    STATE(416), 1,
       sym_inline_statement,
-    STATE(273), 3,
+    STATE(297), 3,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
-  [2588] = 7,
+  [2472] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(439), 1,
+      anon_sym_SPACE,
+    ACTIONS(441), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(443), 1,
+      sym__text_chunk,
+    ACTIONS(445), 2,
+      sym__separator,
+      sym__line_break,
+    STATE(75), 3,
+      sym_name_chunk,
+      sym_scalar_variable,
+      aux_sym_keyword_name_repeat1,
+  [2494] = 7,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(62), 1,
       aux_sym_keyword_token1,
-    ACTIONS(427), 1,
+    ACTIONS(447), 1,
       anon_sym_RETURN,
-    ACTIONS(429), 1,
+    ACTIONS(449), 1,
       anon_sym_DOLLAR_LBRACE,
-    STATE(124), 1,
+    STATE(132), 1,
       sym_keyword,
-    STATE(252), 1,
+    STATE(275), 1,
       sym_inline_statement,
-    STATE(273), 3,
+    STATE(297), 3,
       sym_return_statement,
       sym_variable_assignment,
       sym_keyword_invocation,
+  [2518] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(404), 1,
+      sym_arguments,
+    ACTIONS(451), 2,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [2542] = 7,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(62), 1,
+      aux_sym_keyword_token1,
+    ACTIONS(447), 1,
+      anon_sym_RETURN,
+    ACTIONS(449), 1,
+      anon_sym_DOLLAR_LBRACE,
+    STATE(132), 1,
+      sym_keyword,
+    STATE(237), 1,
+      sym_inline_statement,
+    STATE(297), 3,
+      sym_return_statement,
+      sym_variable_assignment,
+      sym_keyword_invocation,
+  [2566] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(457), 1,
+      sym__separator,
+    ACTIONS(460), 1,
+      sym__line_break,
+    STATE(157), 1,
+      aux_sym_arguments_repeat1,
+    STATE(285), 1,
+      sym_arguments,
+    ACTIONS(455), 2,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+    STATE(201), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [2590] = 6,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(439), 1,
+      anon_sym_SPACE,
+    ACTIONS(441), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(443), 1,
+      sym__text_chunk,
+    ACTIONS(463), 2,
+      sym__separator,
+      sym__line_break,
+    STATE(87), 3,
+      sym_name_chunk,
+      sym_scalar_variable,
+      aux_sym_keyword_name_repeat1,
   [2612] = 6,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(415), 1,
+    ACTIONS(439), 1,
       anon_sym_SPACE,
-    ACTIONS(417), 1,
+    ACTIONS(441), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(419), 1,
+    ACTIONS(443), 1,
       sym__text_chunk,
     ACTIONS(465), 2,
       sym__separator,
       sym__line_break,
-    STATE(76), 3,
+    STATE(75), 3,
       sym_name_chunk,
       sym_scalar_variable,
       aux_sym_keyword_name_repeat1,
   [2634] = 6,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(415), 1,
+    ACTIONS(439), 1,
       anon_sym_SPACE,
-    ACTIONS(417), 1,
+    ACTIONS(441), 1,
       anon_sym_DOLLAR_LBRACE,
-    ACTIONS(419), 1,
+    ACTIONS(443), 1,
       sym__text_chunk,
     ACTIONS(467), 2,
       sym__separator,
       sym__line_break,
-    STATE(83), 3,
+    STATE(81), 3,
       sym_name_chunk,
       sym_scalar_variable,
       aux_sym_keyword_name_repeat1,
   [2656] = 7,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(205), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(211), 1,
-      sym__separator,
-    ACTIONS(469), 1,
+    ACTIONS(310), 1,
       sym__line_break,
-    STATE(11), 1,
+    ACTIONS(312), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(469), 1,
+      sym__separator,
+    STATE(15), 1,
       sym__indentation,
-    STATE(64), 1,
-      sym_keyword_definition_body,
-    STATE(32), 2,
+    STATE(264), 1,
+      sym_block,
+    STATE(107), 2,
       sym__empty_line,
-      aux_sym_keyword_definition_body_repeat1,
+      aux_sym_block_repeat1,
   [2679] = 7,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(296), 1,
+    ACTIONS(310), 1,
       sym__line_break,
-    ACTIONS(298), 1,
+    ACTIONS(312), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(469), 1,
+      sym__separator,
+    STATE(15), 1,
+      sym__indentation,
+    STATE(346), 1,
+      sym_block,
+    STATE(107), 2,
+      sym__empty_line,
+      aux_sym_block_repeat1,
+  [2702] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(310), 1,
+      sym__line_break,
+    ACTIONS(312), 1,
       aux_sym__empty_line_token1,
     ACTIONS(471), 1,
       sym__separator,
-    STATE(13), 1,
+    STATE(15), 1,
       sym__indentation,
-    STATE(268), 1,
+    STATE(370), 1,
       sym_block,
-    STATE(132), 2,
+    STATE(107), 2,
       sym__empty_line,
       aux_sym_block_repeat1,
-  [2702] = 3,
+  [2725] = 7,
     ACTIONS(25), 1,
       sym_comment,
-    STATE(234), 1,
-      sym_keyword_setting_name,
-    ACTIONS(423), 6,
-      aux_sym_setting_name_token5,
-      aux_sym_keyword_setting_name_token1,
-      aux_sym_keyword_setting_name_token2,
-      aux_sym_keyword_setting_name_token3,
-      aux_sym_keyword_setting_name_token4,
-      aux_sym_keyword_setting_name_token5,
-  [2717] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(296), 1,
+    ACTIONS(310), 1,
       sym__line_break,
-    ACTIONS(298), 1,
+    ACTIONS(312), 1,
       aux_sym__empty_line_token1,
-    ACTIONS(473), 1,
+    ACTIONS(474), 1,
       sym__separator,
     STATE(15), 1,
       sym__indentation,
-    STATE(327), 1,
+    STATE(408), 1,
       sym_block,
-    STATE(132), 2,
+    STATE(107), 2,
       sym__empty_line,
       aux_sym_block_repeat1,
-  [2740] = 7,
+  [2748] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(475), 1,
-      sym__separator,
-    STATE(15), 1,
-      sym__indentation,
-    STATE(336), 1,
-      sym_block,
-    STATE(132), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-  [2763] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(201), 1,
-      sym__separator,
-    ACTIONS(205), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(478), 1,
-      sym__line_break,
-    STATE(12), 1,
-      sym__indentation,
-    STATE(66), 1,
-      sym_test_case_definition_body,
-    STATE(31), 2,
-      sym__empty_line,
-      aux_sym_test_case_definition_body_repeat1,
-  [2786] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(473), 1,
-      sym__separator,
-    STATE(15), 1,
-      sym__indentation,
-    STATE(242), 1,
-      sym_block,
-    STATE(132), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-  [2809] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(473), 1,
-      sym__separator,
-    STATE(15), 1,
-      sym__indentation,
-    STATE(435), 1,
-      sym_block,
-    STATE(132), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-  [2832] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(205), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(211), 1,
-      sym__separator,
-    ACTIONS(469), 1,
-      sym__line_break,
-    STATE(11), 1,
-      sym__indentation,
-    STATE(61), 1,
-      sym_keyword_definition_body,
-    STATE(32), 2,
-      sym__empty_line,
-      aux_sym_keyword_definition_body_repeat1,
-  [2855] = 7,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(296), 1,
-      sym__line_break,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(480), 1,
-      sym__separator,
-    STATE(15), 1,
-      sym__indentation,
-    STATE(394), 1,
-      sym_block,
-    STATE(132), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-  [2878] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    STATE(247), 1,
-      sym_test_case_setting_name,
-    ACTIONS(431), 6,
-      aux_sym_setting_name_token5,
-      aux_sym_keyword_setting_name_token1,
-      aux_sym_keyword_setting_name_token4,
-      aux_sym_keyword_setting_name_token5,
-      aux_sym_test_case_setting_name_token1,
-      aux_sym_test_case_setting_name_token2,
-  [2893] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(483), 7,
+    ACTIONS(477), 7,
       ts_builtin_sym_end,
       aux_sym_comments_section_token1,
       aux_sym_settings_section_token1,
@@ -8492,247 +8497,428 @@ static const uint16_t ts_small_parse_table[] = {
       aux_sym_keywords_section_token1,
       aux_sym_test_cases_section_token1,
       aux_sym_test_cases_section_token2,
+  [2761] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(212), 1,
+      sym__separator,
+    ACTIONS(216), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(479), 1,
+      sym__line_break,
+    STATE(11), 1,
+      sym__indentation,
+    STATE(67), 1,
+      sym_keyword_definition_body,
+    STATE(31), 2,
+      sym__empty_line,
+      aux_sym_keyword_definition_body_repeat1,
+  [2784] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(310), 1,
+      sym__line_break,
+    ACTIONS(312), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(469), 1,
+      sym__separator,
+    STATE(15), 1,
+      sym__indentation,
+    STATE(434), 1,
+      sym_block,
+    STATE(107), 2,
+      sym__empty_line,
+      aux_sym_block_repeat1,
+  [2807] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(212), 1,
+      sym__separator,
+    ACTIONS(216), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(479), 1,
+      sym__line_break,
+    STATE(11), 1,
+      sym__indentation,
+    STATE(61), 1,
+      sym_keyword_definition_body,
+    STATE(31), 2,
+      sym__empty_line,
+      aux_sym_keyword_definition_body_repeat1,
+  [2830] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    STATE(283), 1,
+      sym_test_case_setting_name,
+    ACTIONS(419), 6,
+      aux_sym_setting_name_token5,
+      aux_sym_keyword_setting_name_token1,
+      aux_sym_keyword_setting_name_token4,
+      aux_sym_keyword_setting_name_token5,
+      aux_sym_test_case_setting_name_token1,
+      aux_sym_test_case_setting_name_token2,
+  [2845] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    STATE(317), 1,
+      sym_keyword_setting_name,
+    ACTIONS(428), 6,
+      aux_sym_setting_name_token5,
+      aux_sym_keyword_setting_name_token1,
+      aux_sym_keyword_setting_name_token2,
+      aux_sym_keyword_setting_name_token3,
+      aux_sym_keyword_setting_name_token4,
+      aux_sym_keyword_setting_name_token5,
+  [2860] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(216), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(222), 1,
+      sym__separator,
+    ACTIONS(481), 1,
+      sym__line_break,
+    STATE(12), 1,
+      sym__indentation,
+    STATE(64), 1,
+      sym_test_case_definition_body,
+    STATE(32), 2,
+      sym__empty_line,
+      aux_sym_test_case_definition_body_repeat1,
+  [2883] = 7,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(310), 1,
+      sym__line_break,
+    ACTIONS(312), 1,
+      aux_sym__empty_line_token1,
+    ACTIONS(483), 1,
+      sym__separator,
+    STATE(13), 1,
+      sym__indentation,
+    STATE(292), 1,
+      sym_block,
+    STATE(107), 2,
+      sym__empty_line,
+      aux_sym_block_repeat1,
   [2906] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(385), 1,
+    STATE(431), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
   [2926] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(351), 1,
+    STATE(455), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
   [2946] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(463), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [2966] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(326), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(332), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(334), 1,
+      sym__text_chunk,
+    STATE(161), 3,
+      sym_scalar_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [2984] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(341), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3004] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
     ACTIONS(485), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(315), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [2966] = 6,
+      sym__separator,
+    STATE(182), 1,
+      sym__indentation,
+    STATE(243), 1,
+      sym_else_statement,
+    STATE(287), 1,
+      sym_finally_statement,
+    STATE(113), 2,
+      sym_except_statement,
+      aux_sym_try_statement_repeat1,
+  [3024] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(348), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [2986] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(489), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(487), 4,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-      sym__line_break,
-  [3000] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(363), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3020] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(491), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(378), 4,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-      sym__line_break,
-  [3034] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(493), 1,
-      sym__separator,
-    ACTIONS(496), 1,
-      sym__line_break,
-    ACTIONS(499), 1,
+    ACTIONS(312), 1,
       aux_sym__empty_line_token1,
+    ACTIONS(487), 1,
+      sym__separator,
+    ACTIONS(490), 1,
+      sym__line_break,
     STATE(15), 1,
       sym__indentation,
-    STATE(108), 2,
+    STATE(116), 2,
       sym__empty_line,
       aux_sym_block_repeat1,
-  [3054] = 6,
+  [3044] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(485), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    STATE(182), 1,
+      sym__indentation,
+    STATE(243), 1,
+      sym_else_statement,
+    STATE(287), 1,
+      sym_finally_statement,
+    STATE(195), 2,
+      sym_except_statement,
+      aux_sym_try_statement_repeat1,
+  [3064] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(398), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3084] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
     STATE(373), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3074] = 6,
+  [3104] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(502), 1,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(267), 1,
+    STATE(375), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3094] = 6,
+  [3124] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(492), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(296), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3144] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(495), 1,
+      sym__separator,
+    STATE(183), 1,
+      sym__indentation,
+    STATE(238), 1,
+      sym_else_statement,
+    STATE(302), 1,
+      sym_finally_statement,
+    STATE(195), 2,
+      sym_except_statement,
+      aux_sym_try_statement_repeat1,
+  [3164] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(497), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(407), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3184] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(501), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(499), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3198] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(503), 1,
+      sym__separator,
+    ACTIONS(506), 1,
+      sym__line_break,
+    ACTIONS(509), 1,
+      aux_sym__empty_line_token1,
+    STATE(15), 1,
+      sym__indentation,
+    STATE(116), 2,
+      sym__empty_line,
+      aux_sym_block_repeat1,
+  [3218] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
     STATE(421), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3114] = 6,
+  [3238] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(323), 1,
+    STATE(429), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3134] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(324), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3154] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(356), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3174] = 3,
+  [3258] = 5,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(507), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(505), 4,
-      anon_sym_SPACE,
+    ACTIONS(274), 1,
       anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-      sym__line_break,
-  [3188] = 6,
+    ACTIONS(280), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(282), 1,
+      sym__text_chunk,
+    STATE(133), 3,
+      sym_scalar_variable,
+      sym_inline_python_expression,
+      sym_text_chunk,
+  [3276] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(453), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(156), 1,
       aux_sym_arguments_repeat1,
-    STATE(367), 1,
+    STATE(443), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(230), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3208] = 6,
+  [3296] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(509), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    STATE(181), 1,
-      sym__indentation,
-    STATE(226), 1,
-      sym_else_statement,
-    STATE(257), 1,
-      sym_finally_statement,
-    STATE(137), 2,
-      sym_except_statement,
-      aux_sym_try_statement_repeat1,
-  [3228] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(513), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(511), 4,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
+    ACTIONS(453), 1,
       sym__line_break,
-  [3242] = 3,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(445), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3316] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(451), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3336] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(512), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(269), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3356] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(517), 2,
@@ -8743,21 +8929,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3256] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(345), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3276] = 3,
+  [3370] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(521), 2,
@@ -8768,7 +8940,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3290] = 3,
+  [3384] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(525), 2,
@@ -8779,7 +8951,7 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3304] = 3,
+  [3398] = 3,
     ACTIONS(3), 1,
       sym_comment,
     ACTIONS(529), 2,
@@ -8790,606 +8962,1026 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3318] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(531), 1,
-      sym__separator,
-    ACTIONS(534), 1,
-      sym__line_break,
-    STATE(172), 1,
-      aux_sym_arguments_repeat1,
-    STATE(267), 1,
-      sym_arguments,
-    STATE(192), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3338] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(439), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(364), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3358] = 3,
+  [3412] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(539), 2,
+    ACTIONS(533), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
       sym__text_chunk,
-    ACTIONS(537), 4,
+    ACTIONS(531), 4,
       anon_sym_SPACE,
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3372] = 3,
+  [3426] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(543), 2,
+    ACTIONS(537), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
       sym__text_chunk,
-    ACTIONS(541), 4,
+    ACTIONS(535), 4,
       anon_sym_SPACE,
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3386] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(547), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(545), 4,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-      sym__line_break,
-  [3400] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(549), 1,
-      sym__line_break,
-    STATE(146), 1,
-      aux_sym_arguments_repeat1,
-    STATE(312), 1,
-      sym_arguments,
-    STATE(208), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [3420] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(552), 1,
-      sym__separator,
-    ACTIONS(555), 1,
-      sym__line_break,
-    STATE(172), 1,
-      aux_sym_arguments_repeat1,
-    STATE(312), 1,
-      sym_arguments,
-    STATE(192), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
   [3440] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(560), 2,
+    ACTIONS(541), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
       sym__text_chunk,
-    ACTIONS(558), 4,
+    ACTIONS(539), 4,
       anon_sym_SPACE,
       anon_sym_DOLLAR_LBRACE,
       sym__separator,
       sym__line_break,
-  [3454] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(298), 1,
-      aux_sym__empty_line_token1,
-    ACTIONS(562), 1,
-      sym__separator,
-    ACTIONS(565), 1,
-      sym__line_break,
-    STATE(15), 1,
-      sym__indentation,
-    STATE(108), 2,
-      sym__empty_line,
-      aux_sym_block_repeat1,
-  [3474] = 5,
+  [3454] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(274), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(280), 1,
+    ACTIONS(545), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(282), 1,
       sym__text_chunk,
-    STATE(107), 3,
-      sym_scalar_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [3492] = 6,
+    ACTIONS(543), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3468] = 6,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(547), 1,
       sym__separator,
-    ACTIONS(439), 1,
+    ACTIONS(550), 1,
       sym__line_break,
-    STATE(146), 1,
+    STATE(157), 1,
       aux_sym_arguments_repeat1,
-    STATE(441), 1,
+    STATE(269), 1,
       sym_arguments,
-    STATE(208), 2,
+    STATE(201), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3512] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(509), 1,
-      sym__separator,
-    STATE(181), 1,
-      sym__indentation,
-    STATE(226), 1,
-      sym_else_statement,
-    STATE(257), 1,
-      sym_finally_statement,
-    STATE(183), 2,
-      sym_except_statement,
-      aux_sym_try_statement_repeat1,
-  [3532] = 5,
+  [3488] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(284), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(290), 1,
+    ACTIONS(553), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(292), 1,
       sym__text_chunk,
-    STATE(149), 3,
+    ACTIONS(374), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3502] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(557), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(555), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3516] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(561), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(559), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3530] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(565), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(563), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3544] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(569), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(567), 4,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+      sym__line_break,
+  [3558] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(571), 1,
+      sym__separator,
+    ACTIONS(574), 1,
+      sym__line_break,
+    STATE(157), 1,
+      aux_sym_arguments_repeat1,
+    STATE(296), 1,
+      sym_arguments,
+    STATE(201), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3578] = 5,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(298), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(304), 1,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+    ACTIONS(306), 1,
+      sym__text_chunk,
+    STATE(143), 3,
       sym_scalar_variable,
       sym_inline_python_expression,
       sym_text_chunk,
-  [3550] = 6,
+  [3596] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(453), 1,
+      sym__line_break,
+    STATE(156), 1,
+      aux_sym_arguments_repeat1,
+    STATE(340), 1,
+      sym_arguments,
+    STATE(230), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [3616] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(501), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(499), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [3629] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(521), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(519), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3642] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(553), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(374), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3655] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(579), 2,
+      anon_sym_DOLLAR_LBRACE,
+      sym__text_chunk,
+    ACTIONS(577), 3,
+      anon_sym_SPACE,
+      sym__separator,
+      sym__line_break,
+  [3668] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(581), 1,
+      sym__separator,
+    STATE(190), 1,
+      aux_sym_if_statement_repeat1,
+    STATE(229), 1,
+      sym__indentation,
+    STATE(258), 1,
+      sym_else_statement,
+    STATE(379), 1,
+      sym_elseif_statement,
+  [3687] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(535), 1,
+      sym__separator,
+    ACTIONS(537), 4,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      anon_sym_RBRACK,
+      sym__line_break,
+  [3700] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(567), 1,
       sym__separator,
-    STATE(187), 1,
-      sym__indentation,
-    STATE(207), 1,
-      sym_else_statement,
-    STATE(287), 1,
-      sym_finally_statement,
-    STATE(183), 2,
-      sym_except_statement,
-      aux_sym_try_statement_repeat1,
-  [3570] = 5,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(322), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(328), 1,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-    ACTIONS(330), 1,
-      sym__text_chunk,
-    STATE(159), 3,
-      sym_scalar_variable,
-      sym_inline_python_expression,
-      sym_text_chunk,
-  [3588] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(571), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
     ACTIONS(569), 4,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      anon_sym_RBRACK,
       sym__line_break,
-  [3602] = 6,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(573), 1,
-      sym__separator,
-    STATE(173), 1,
-      aux_sym_if_statement_repeat1,
-    STATE(218), 1,
-      sym__indentation,
-    STATE(238), 1,
-      sym_else_statement,
-    STATE(369), 1,
-      sym_elseif_statement,
-  [3621] = 3,
+  [3713] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(539), 2,
+    ACTIONS(501), 2,
       anon_sym_DOLLAR_LBRACE_LBRACE,
       sym__text_chunk,
-    ACTIONS(537), 3,
+    ACTIONS(499), 3,
       anon_sym_SPACE,
       anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3634] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(577), 2,
-      anon_sym_DOLLAR_LBRACE,
-      sym__text_chunk,
-    ACTIONS(575), 3,
-      anon_sym_SPACE,
-      sym__separator,
       sym__line_break,
-  [3647] = 6,
+  [3726] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(579), 1,
+    ACTIONS(523), 1,
       sym__separator,
-    STATE(145), 1,
-      aux_sym_if_statement_repeat1,
-    STATE(216), 1,
-      sym__indentation,
-    STATE(235), 1,
-      sym_else_statement,
-    STATE(369), 1,
-      sym_elseif_statement,
-  [3666] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(581), 2,
-      anon_sym_DOLLAR_LBRACE,
-      sym__text_chunk,
-    ACTIONS(455), 3,
-      anon_sym_SPACE,
-      sym__separator,
+    ACTIONS(525), 4,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      anon_sym_RBRACK,
       sym__line_break,
-  [3679] = 6,
+  [3739] = 6,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(583), 1,
       sym__separator,
-    STATE(173), 1,
+    STATE(190), 1,
       aux_sym_if_statement_repeat1,
-    STATE(204), 1,
+    STATE(236), 1,
       sym__indentation,
-    STATE(245), 1,
+    STATE(267), 1,
       sym_else_statement,
-    STATE(369), 1,
+    STATE(379), 1,
       sym_elseif_statement,
-  [3698] = 5,
+  [3758] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(517), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(515), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3771] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(410), 1,
+    ACTIONS(555), 1,
+      sym__separator,
+    ACTIONS(557), 4,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      anon_sym_RBRACK,
+      sym__line_break,
+  [3784] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(525), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(523), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3797] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(529), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(527), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3810] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(533), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(531), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3823] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
       sym__separator,
     ACTIONS(585), 1,
       sym__line_break,
-    STATE(222), 1,
+    STATE(240), 1,
       aux_sym_arguments_repeat1,
-    STATE(223), 2,
+    STATE(241), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [3715] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(560), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(558), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3728] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(489), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(487), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3741] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(491), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(378), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3754] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(507), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(505), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3767] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(571), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(569), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3780] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(513), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(511), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3793] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(517), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(515), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3806] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(560), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(558), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3819] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(521), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(519), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3832] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(525), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(523), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3845] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(529), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(527), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3858] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(489), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(487), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3871] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(491), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(378), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3884] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(539), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(537), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3897] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(543), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(541), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3910] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(547), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(545), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__line_break,
-  [3923] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(507), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(505), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3936] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(513), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(511), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3949] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(517), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(515), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3962] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(525), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(523), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3975] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(529), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(527), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [3988] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(543), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(541), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [4001] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(547), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(545), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [4014] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(571), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(569), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [4027] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(521), 2,
-      anon_sym_DOLLAR_LBRACE_LBRACE,
-      sym__text_chunk,
-    ACTIONS(519), 3,
-      anon_sym_SPACE,
-      anon_sym_DOLLAR_LBRACE,
-      sym__separator,
-  [4040] = 5,
+  [3840] = 5,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(588), 1,
       sym__separator,
     ACTIONS(591), 1,
       sym__line_break,
-    STATE(222), 1,
+    STATE(240), 1,
       aux_sym_arguments_repeat1,
-    STATE(194), 2,
+    STATE(204), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [4057] = 5,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(594), 1,
-      sym__separator,
-    STATE(173), 1,
-      aux_sym_if_statement_repeat1,
-    STATE(369), 1,
-      sym_elseif_statement,
-    STATE(382), 1,
-      sym__indentation,
-  [4073] = 4,
+  [3857] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(599), 1,
+    ACTIONS(541), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(539), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3870] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(545), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(543), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3883] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(521), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(519), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [3896] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(553), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(374), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [3909] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(557), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(555), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3922] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(561), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(559), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3935] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(565), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(563), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3948] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(569), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(567), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [3961] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(517), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(515), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [3974] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(529), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(527), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [3987] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(533), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(531), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4000] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(541), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(539), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4013] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(545), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(543), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4026] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(561), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(559), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4039] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(565), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(563), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4052] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(525), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(523), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4065] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(537), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(535), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4078] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(557), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(555), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4091] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(569), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(567), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__separator,
+  [4104] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(594), 2,
+      anon_sym_DOLLAR_LBRACE,
+      sym__text_chunk,
+    ACTIONS(417), 3,
+      anon_sym_SPACE,
+      sym__separator,
+      sym__line_break,
+  [4117] = 6,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(596), 1,
+      sym__separator,
+    STATE(150), 1,
+      aux_sym_if_statement_repeat1,
+    STATE(254), 1,
+      sym__indentation,
+    STATE(256), 1,
+      sym_else_statement,
+    STATE(379), 1,
+      sym_elseif_statement,
+  [4136] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(537), 2,
+      anon_sym_DOLLAR_LBRACE_LBRACE,
+      sym__text_chunk,
+    ACTIONS(535), 3,
+      anon_sym_SPACE,
+      anon_sym_DOLLAR_LBRACE,
+      sym__line_break,
+  [4149] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(598), 1,
+      anon_sym_SPACE,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(602), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4165] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(604), 1,
+      anon_sym_SPACE,
+    ACTIONS(606), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4181] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(68), 1,
+      anon_sym_ELSE,
+    ACTIONS(72), 1,
+      anon_sym_EXCEPT,
+    ACTIONS(74), 1,
+      anon_sym_FINALLY,
+    ACTIONS(608), 1,
+      anon_sym_END,
+  [4197] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(68), 1,
+      anon_sym_ELSE,
+    ACTIONS(72), 1,
+      anon_sym_EXCEPT,
+    ACTIONS(74), 1,
+      anon_sym_FINALLY,
+    ACTIONS(610), 1,
+      anon_sym_END,
+  [4213] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(531), 1,
+      sym__separator,
+    ACTIONS(533), 3,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      sym__line_break,
+  [4225] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(612), 1,
+      anon_sym_SPACE,
+    ACTIONS(614), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4241] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(616), 1,
+      anon_sym_SPACE,
+    ACTIONS(618), 1,
+      anon_sym_LBRACK,
+    ACTIONS(621), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4257] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(539), 1,
+      sym__separator,
+    ACTIONS(541), 3,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      sym__line_break,
+  [4269] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(623), 1,
+      anon_sym_ELSEIF,
+    ACTIONS(625), 1,
+      anon_sym_ELSE,
+    STATE(265), 1,
+      sym_inline_elseif_statement,
+    STATE(331), 1,
+      sym_inline_else_statement,
+  [4285] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(627), 1,
+      sym__line_break,
+    STATE(244), 1,
+      aux_sym_arguments_repeat1,
+    STATE(381), 1,
+      sym_arguments_without_continuation,
+  [4301] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(629), 1,
+      sym__separator,
+    STATE(190), 1,
+      aux_sym_if_statement_repeat1,
+    STATE(357), 1,
+      sym__indentation,
+    STATE(379), 1,
+      sym_elseif_statement,
+  [4317] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(543), 1,
+      sym__separator,
+    ACTIONS(545), 3,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      sym__line_break,
+  [4329] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(623), 1,
+      anon_sym_ELSEIF,
+    ACTIONS(625), 1,
+      anon_sym_ELSE,
+    STATE(265), 1,
+      sym_inline_elseif_statement,
+    STATE(384), 1,
+      sym_inline_else_statement,
+  [4345] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(559), 1,
+      sym__separator,
+    ACTIONS(561), 3,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      sym__line_break,
+  [4357] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(563), 1,
+      sym__separator,
+    ACTIONS(565), 3,
+      anon_sym_EQ,
+      anon_sym_EQ2,
+      sym__line_break,
+  [4369] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(632), 1,
+      sym__separator,
+    STATE(413), 1,
+      sym__indentation,
+    STATE(195), 2,
+      sym_except_statement,
+      aux_sym_try_statement_repeat1,
+  [4383] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(635), 1,
+      anon_sym_SPACE,
+    ACTIONS(637), 1,
+      anon_sym_RBRACE,
+    STATE(185), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4399] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(641), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(210), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(639), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4413] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(441), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(443), 1,
+      sym__text_chunk,
+    STATE(177), 2,
+      sym_name_chunk,
+      sym_scalar_variable,
+  [4427] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(643), 1,
+      anon_sym_SPACE,
+    ACTIONS(645), 1,
+      anon_sym_RBRACE,
+    STATE(214), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4443] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(647), 1,
       anon_sym_RBRACE_RBRACE,
     STATE(197), 1,
       aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
+    ACTIONS(639), 2,
       anon_sym_RBRACE,
       aux_sym_inline_python_expression_token1,
-  [4087] = 5,
+  [4457] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(601), 1,
-      anon_sym_ELSEIF,
-    ACTIONS(603), 1,
-      anon_sym_ELSE,
-    STATE(243), 1,
-      sym_inline_elseif_statement,
-    STATE(402), 1,
-      sym_inline_else_statement,
-  [4103] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(519), 1,
-      sym__separator,
-    ACTIONS(521), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
+    ACTIONS(591), 1,
       sym__line_break,
-  [4115] = 3,
+    ACTIONS(649), 1,
+      sym__separator,
+    STATE(205), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [4471] = 5,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(523), 1,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(651), 1,
+      anon_sym_SPACE,
+    ACTIONS(653), 1,
+      anon_sym_RBRACE,
+    STATE(207), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4487] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(655), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(208), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(639), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4501] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(657), 1,
       sym__separator,
-    ACTIONS(525), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
+    ACTIONS(659), 1,
       sym__line_break,
-  [4127] = 3,
+    STATE(205), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [4515] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(662), 1,
+      sym__separator,
+    ACTIONS(664), 1,
+      sym__line_break,
+    STATE(205), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [4529] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(667), 1,
+      anon_sym_SPACE,
+    ACTIONS(669), 1,
+      anon_sym_RBRACE,
+    STATE(209), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4545] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(667), 1,
+      anon_sym_SPACE,
+    ACTIONS(669), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4561] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(671), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(210), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(639), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4575] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(673), 1,
+      anon_sym_SPACE,
+    ACTIONS(675), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4591] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(680), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(210), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(677), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4605] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(682), 1,
+      anon_sym_SPACE,
+    ACTIONS(684), 1,
+      anon_sym_RBRACE,
+    STATE(180), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4621] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(686), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(215), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(639), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4635] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(598), 1,
+      anon_sym_SPACE,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(602), 1,
+      anon_sym_RBRACE,
+    STATE(216), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4651] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(635), 1,
+      anon_sym_SPACE,
+    ACTIONS(637), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4667] = 4,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(688), 1,
+      anon_sym_RBRACE_RBRACE,
+    STATE(210), 1,
+      aux_sym_inline_python_expression_repeat1,
+    ACTIONS(639), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4681] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(690), 1,
+      anon_sym_SPACE,
+    ACTIONS(692), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4697] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(694), 1,
+      anon_sym_SPACE,
+    ACTIONS(696), 1,
+      anon_sym_RBRACE,
+    STATE(219), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4713] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(698), 1,
+      anon_sym_SPACE,
+    ACTIONS(700), 1,
+      anon_sym_RBRACE,
+    STATE(220), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4729] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(698), 1,
+      anon_sym_SPACE,
+    ACTIONS(700), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4745] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(702), 1,
+      anon_sym_SPACE,
+    ACTIONS(704), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4761] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(706), 1,
+      anon_sym_SPACE,
+    ACTIONS(708), 1,
+      anon_sym_RBRACE,
+    STATE(223), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4777] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(710), 1,
+      anon_sym_SPACE,
+    ACTIONS(712), 1,
+      anon_sym_RBRACE,
+    STATE(181), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4793] = 5,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(600), 1,
+      anon_sym_LBRACK,
+    ACTIONS(710), 1,
+      anon_sym_SPACE,
+    ACTIONS(712), 1,
+      anon_sym_RBRACE,
+    STATE(186), 1,
+      aux_sym_scalar_variable_repeat1,
+  [4809] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(527), 1,
@@ -9398,215 +9990,244 @@ static const uint16_t ts_small_parse_table[] = {
       anon_sym_EQ,
       anon_sym_EQ2,
       sym__line_break,
-  [4139] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(605), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(174), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4153] = 3,
+  [4821] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(569), 1,
+    ACTIONS(714), 1,
       sym__separator,
-    ACTIONS(571), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
+    ACTIONS(717), 1,
       sym__line_break,
-  [4165] = 5,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(68), 1,
-      anon_sym_ELSE,
-    ACTIONS(72), 1,
-      anon_sym_EXCEPT,
-    ACTIONS(74), 1,
-      anon_sym_FINALLY,
-    ACTIONS(607), 1,
-      anon_sym_END,
-  [4181] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(511), 1,
-      sym__separator,
-    ACTIONS(513), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
-      sym__line_break,
-  [4193] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(609), 1,
-      sym__separator,
-    STATE(374), 1,
-      sym__indentation,
-    STATE(183), 2,
-      sym_except_statement,
-      aux_sym_try_statement_repeat1,
-  [4207] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(515), 1,
-      sym__separator,
-    ACTIONS(517), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
-      sym__line_break,
-  [4219] = 5,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(612), 1,
-      sym__line_break,
-    STATE(201), 1,
+    STATE(226), 1,
       aux_sym_arguments_repeat1,
-    STATE(362), 1,
-      sym_arguments_without_continuation,
-  [4235] = 3,
+  [4834] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(545), 1,
+    ACTIONS(719), 1,
       sym__separator,
-    ACTIONS(547), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
+    ACTIONS(722), 1,
       sym__line_break,
-  [4247] = 5,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(68), 1,
-      anon_sym_ELSE,
-    ACTIONS(72), 1,
-      anon_sym_EXCEPT,
-    ACTIONS(74), 1,
-      anon_sym_FINALLY,
-    ACTIONS(614), 1,
-      anon_sym_END,
-  [4263] = 4,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [4847] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(417), 1,
-      anon_sym_DOLLAR_LBRACE,
-    ACTIONS(419), 1,
-      sym__text_chunk,
-    STATE(144), 2,
-      sym_name_chunk,
-      sym_scalar_variable,
-  [4277] = 5,
+    ACTIONS(726), 1,
+      anon_sym_RBRACE_RBRACE,
+    ACTIONS(724), 2,
+      anon_sym_RBRACE,
+      aux_sym_inline_python_expression_token1,
+  [4858] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(601), 1,
+    ACTIONS(728), 1,
+      sym_ellipses,
+    ACTIONS(730), 1,
+      sym__separator,
+    STATE(387), 1,
+      sym__indentation,
+  [4871] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(84), 1,
       anon_sym_ELSEIF,
-    ACTIONS(603), 1,
+    ACTIONS(86), 1,
       anon_sym_ELSE,
-    STATE(243), 1,
-      sym_inline_elseif_statement,
-    STATE(365), 1,
-      sym_inline_else_statement,
-  [4293] = 3,
+    ACTIONS(732), 1,
+      anon_sym_END,
+  [4884] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(537), 1,
-      sym__separator,
-    ACTIONS(539), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
+    ACTIONS(585), 1,
       sym__line_break,
-  [4305] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(541), 1,
-      sym__separator,
-    ACTIONS(543), 3,
-      anon_sym_EQ,
-      anon_sym_EQ2,
-      sym__line_break,
-  [4317] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(591), 1,
-      sym__line_break,
-    ACTIONS(616), 1,
-      sym__separator,
-    STATE(195), 2,
+    STATE(246), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [4331] = 4,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(618), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(196), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4345] = 4,
+  [4895] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(620), 1,
-      sym__separator,
-    ACTIONS(622), 1,
-      sym__line_break,
-    STATE(195), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [4359] = 4,
+    ACTIONS(734), 1,
+      anon_sym_SPACE,
+    ACTIONS(736), 2,
+      anon_sym_LBRACK,
+      anon_sym_RBRACE,
+  [4906] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(625), 1,
+    ACTIONS(434), 1,
       sym__separator,
-    ACTIONS(627), 1,
+    ACTIONS(717), 1,
       sym__line_break,
-    STATE(195), 2,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [4919] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(738), 1,
+      sym__line_break,
+    STATE(232), 1,
+      aux_sym_arguments_repeat1,
+  [4932] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(742), 1,
+      sym__line_break,
+    ACTIONS(740), 2,
+      sym__separator,
+      aux_sym__empty_line_token1,
+  [4943] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(744), 1,
+      sym__separator,
+    ACTIONS(747), 1,
+      sym__line_break,
+    STATE(235), 1,
+      aux_sym_inline_if_statement_repeat1,
+  [4956] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(84), 1,
+      anon_sym_ELSEIF,
+    ACTIONS(86), 1,
+      anon_sym_ELSE,
+    ACTIONS(749), 1,
+      anon_sym_END,
+  [4969] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(751), 1,
+      sym__separator,
+    ACTIONS(753), 1,
+      sym__line_break,
+    STATE(251), 1,
+      aux_sym_inline_if_statement_repeat1,
+  [4982] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(755), 1,
+      sym__separator,
+    STATE(259), 1,
+      sym_finally_statement,
+    STATE(260), 1,
+      sym__indentation,
+  [4995] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(423), 1,
+      sym_ellipses,
+    ACTIONS(757), 1,
+      sym__separator,
+    STATE(465), 1,
+      sym__indentation,
+  [5008] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(759), 1,
+      sym__separator,
+    ACTIONS(762), 1,
+      sym__line_break,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [5021] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(764), 1,
+      sym__line_break,
+    STATE(246), 2,
       sym_continuation,
       aux_sym_arguments_repeat2,
-  [4373] = 4,
+  [5032] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    STATE(244), 1,
+      aux_sym_arguments_repeat1,
+    STATE(334), 1,
+      sym_arguments_without_continuation,
+  [5045] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(767), 1,
+      sym__separator,
+    STATE(255), 1,
+      sym__indentation,
+    STATE(302), 1,
+      sym_finally_statement,
+  [5058] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(769), 1,
+      sym__line_break,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [5071] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(714), 1,
+      sym__separator,
+    ACTIONS(717), 1,
+      sym__line_break,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [5084] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(771), 1,
+      sym__line_break,
+    STATE(246), 2,
+      sym_continuation,
+      aux_sym_arguments_repeat2,
+  [5095] = 4,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(722), 1,
+      sym__line_break,
+    STATE(240), 1,
+      aux_sym_arguments_repeat1,
+  [5108] = 4,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(630), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(197), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4387] = 4,
-    ACTIONS(3), 1,
+    ACTIONS(119), 1,
+      anon_sym_DOLLAR_LBRACE,
+    ACTIONS(774), 1,
+      sym_variable_key,
+    STATE(469), 1,
+      sym_scalar_variable,
+  [5121] = 4,
+    ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(635), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(197), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(632), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4401] = 4,
-    ACTIONS(3), 1,
+    ACTIONS(434), 1,
+      sym__separator,
+    ACTIONS(717), 1,
+      sym__line_break,
+    STATE(247), 1,
+      aux_sym_arguments_repeat1,
+  [5134] = 4,
+    ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(637), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(199), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4415] = 4,
-    ACTIONS(3), 1,
+    ACTIONS(776), 1,
+      sym__separator,
+    STATE(287), 1,
+      sym_finally_statement,
+    STATE(288), 1,
+      sym__indentation,
+  [5147] = 4,
+    ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(639), 1,
-      anon_sym_RBRACE_RBRACE,
-    STATE(197), 1,
-      aux_sym_inline_python_expression_repeat1,
-    ACTIONS(597), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4429] = 3,
+    ACTIONS(778), 1,
+      sym__separator,
+    ACTIONS(780), 1,
+      sym__line_break,
+    STATE(235), 1,
+      aux_sym_inline_if_statement_repeat1,
+  [5160] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(50), 1,
@@ -9614,1513 +10235,1258 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(52), 2,
       sym__separator,
       aux_sym__empty_line_token1,
-  [4440] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(641), 1,
-      sym__line_break,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4453] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(643), 1,
-      sym__separator,
-    ACTIONS(646), 1,
-      sym__line_break,
-    STATE(202), 1,
-      aux_sym_inline_if_statement_repeat1,
-  [4466] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(648), 1,
-      sym__line_break,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4479] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(84), 1,
-      anon_sym_ELSEIF,
-    ACTIONS(86), 1,
-      anon_sym_ELSE,
-    ACTIONS(650), 1,
-      anon_sym_END,
-  [4492] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(652), 1,
-      sym__separator,
-    ACTIONS(654), 1,
-      sym__line_break,
-    STATE(214), 1,
-      aux_sym_inline_if_statement_repeat1,
-  [4505] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(656), 1,
-      sym__separator,
-    ACTIONS(659), 1,
-      sym__line_break,
-    STATE(209), 1,
-      aux_sym_arguments_repeat1,
-  [4518] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(661), 1,
-      sym__separator,
-    STATE(239), 1,
-      sym_finally_statement,
-    STATE(240), 1,
-      sym__indentation,
-  [4531] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(585), 1,
-      sym__line_break,
-    STATE(224), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [4542] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(663), 1,
-      sym__separator,
-    ACTIONS(666), 1,
-      sym__line_break,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4555] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(670), 1,
-      sym__line_break,
-    ACTIONS(668), 2,
-      sym__separator,
-      aux_sym__empty_line_token1,
-  [4566] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(441), 1,
-      sym_ellipses,
-    ACTIONS(672), 1,
-      sym__separator,
-    STATE(320), 1,
-      sym__indentation,
-  [4579] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(676), 1,
-      anon_sym_RBRACE_RBRACE,
-    ACTIONS(674), 2,
-      anon_sym_RBRACE,
-      aux_sym_inline_python_expression_token1,
-  [4590] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(663), 1,
-      sym__separator,
-    ACTIONS(666), 1,
-      sym__line_break,
-    STATE(220), 1,
-      aux_sym_arguments_repeat1,
-  [4603] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(678), 1,
-      sym__separator,
-    ACTIONS(680), 1,
-      sym__line_break,
-    STATE(202), 1,
-      aux_sym_inline_if_statement_repeat1,
-  [4616] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(682), 1,
-      sym__separator,
-    STATE(257), 1,
-      sym_finally_statement,
-    STATE(260), 1,
-      sym__indentation,
-  [4629] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(84), 1,
-      anon_sym_ELSEIF,
-    ACTIONS(86), 1,
-      anon_sym_ELSE,
-    ACTIONS(684), 1,
-      anon_sym_END,
-  [4642] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(659), 1,
-      sym__line_break,
-    STATE(225), 1,
-      aux_sym_arguments_repeat1,
-  [4655] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(84), 1,
-      anon_sym_ELSEIF,
-    ACTIONS(86), 1,
-      anon_sym_ELSE,
-    ACTIONS(686), 1,
-      anon_sym_END,
-  [4668] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(688), 1,
-      sym_ellipses,
-    ACTIONS(690), 1,
-      sym__separator,
-    STATE(375), 1,
-      sym__indentation,
-  [4681] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(648), 1,
-      sym__line_break,
-    ACTIONS(692), 1,
-      sym__separator,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4694] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    STATE(201), 1,
-      aux_sym_arguments_repeat1,
-    STATE(319), 1,
-      sym_arguments_without_continuation,
-  [4707] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(695), 1,
-      sym__separator,
-    ACTIONS(698), 1,
-      sym__line_break,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4720] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(700), 1,
-      sym__line_break,
-    STATE(224), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [4731] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(703), 1,
-      sym__line_break,
-    STATE(224), 2,
-      sym_continuation,
-      aux_sym_arguments_repeat2,
-  [4742] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(666), 1,
-      sym__line_break,
-    STATE(222), 1,
-      aux_sym_arguments_repeat1,
-  [4755] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(706), 1,
-      sym__separator,
-    STATE(287), 1,
-      sym_finally_statement,
-    STATE(291), 1,
-      sym__indentation,
-  [4768] = 4,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(410), 1,
-      sym__separator,
-    ACTIONS(666), 1,
-      sym__line_break,
-    STATE(203), 1,
-      aux_sym_arguments_repeat1,
-  [4781] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(708), 1,
-      sym__separator,
-    STATE(246), 1,
-      aux_sym_for_statement_repeat1,
-  [4791] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(710), 1,
-      anon_sym_SPACE,
-    ACTIONS(712), 1,
-      sym_variable_name,
-  [4801] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(714), 1,
-      sym__separator,
-    ACTIONS(716), 1,
-      sym__line_break,
-  [4811] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(718), 1,
-      sym__separator,
-    ACTIONS(720), 1,
-      sym__line_break,
-  [4821] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(698), 1,
-      sym__line_break,
-    ACTIONS(722), 1,
-      sym__separator,
-  [4831] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(724), 1,
-      sym__separator,
-    ACTIONS(726), 1,
-      sym__line_break,
-  [4841] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(728), 1,
-      anon_sym_SPACE,
-    ACTIONS(730), 1,
-      anon_sym_RBRACK,
-  [4851] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(732), 1,
-      sym__separator,
-    STATE(371), 1,
-      sym__indentation,
-  [4861] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(734), 1,
-      aux_sym_comments_section_token2,
-    ACTIONS(736), 1,
-      sym__line_break,
-  [4871] = 3,
+  [5171] = 4,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(738), 1,
+      sym__line_break,
+    ACTIONS(782), 1,
       sym__separator,
-    STATE(337), 1,
-      sym__indentation,
-  [4881] = 3,
+    STATE(245), 1,
+      aux_sym_arguments_repeat1,
+  [5184] = 4,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(740), 1,
-      sym__separator,
-    STATE(378), 1,
-      sym__indentation,
-  [4891] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(742), 1,
-      sym__separator,
-    STATE(393), 1,
-      sym__indentation,
-  [4901] = 3,
+    ACTIONS(84), 1,
+      anon_sym_ELSEIF,
+    ACTIONS(86), 1,
+      anon_sym_ELSE,
+    ACTIONS(785), 1,
+      anon_sym_END,
+  [5197] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(74), 1,
       anon_sym_FINALLY,
-    ACTIONS(744), 1,
+    ACTIONS(610), 1,
       anon_sym_END,
-  [4911] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(746), 1,
-      sym__separator,
-    ACTIONS(748), 1,
-      sym__line_break,
-  [4921] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(750), 1,
-      sym__separator,
-    STATE(396), 1,
-      sym__indentation,
-  [4931] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(646), 1,
-      sym__line_break,
-    ACTIONS(752), 1,
-      sym__separator,
-  [4941] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(754), 1,
-      aux_sym_comments_section_token2,
-    ACTIONS(756), 1,
-      sym__line_break,
-  [4951] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(758), 1,
-      sym__separator,
-    STATE(409), 1,
-      sym__indentation,
-  [4961] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(760), 1,
-      sym__separator,
-    STATE(246), 1,
-      aux_sym_for_statement_repeat1,
-  [4971] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(763), 1,
-      anon_sym_SPACE,
-    ACTIONS(765), 1,
-      anon_sym_RBRACK,
-  [4981] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(767), 1,
-      aux_sym_comments_section_token2,
-    ACTIONS(769), 1,
-      sym__line_break,
-  [4991] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(601), 1,
-      anon_sym_ELSEIF,
-    STATE(243), 1,
-      sym_inline_elseif_statement,
-  [5001] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(771), 1,
-      sym__separator,
-    ACTIONS(773), 1,
-      sym__line_break,
-  [5011] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(775), 1,
-      anon_sym_SPACE,
-    ACTIONS(777), 1,
-      anon_sym_RBRACE,
-  [5021] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(779), 1,
-      sym__separator,
-    ACTIONS(781), 1,
-      sym__line_break,
-  [5031] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(783), 1,
-      sym__separator,
-    ACTIONS(785), 1,
-      sym__line_break,
-  [5041] = 3,
+  [5207] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(787), 1,
-      anon_sym_SPACE,
+      sym__separator,
+    STATE(339), 1,
+      sym__indentation,
+  [5217] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
     ACTIONS(789), 1,
-      anon_sym_RBRACK,
-  [5051] = 3,
+      aux_sym_comments_section_token2,
+    ACTIONS(791), 1,
+      sym__line_break,
+  [5227] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(791), 1,
-      anon_sym_SPACE,
     ACTIONS(793), 1,
-      anon_sym_RBRACK,
-  [5061] = 3,
+      sym__separator,
+    STATE(348), 1,
+      sym__indentation,
+  [5237] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(795), 1,
-      anon_sym_SPACE,
-    ACTIONS(797), 1,
-      anon_sym_RBRACE,
-  [5071] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(799), 1,
       sym__separator,
-    STATE(384), 1,
+    STATE(362), 1,
       sym__indentation,
-  [5081] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(801), 1,
-      anon_sym_SPACE,
-    ACTIONS(803), 1,
-      anon_sym_RBRACE,
-  [5091] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(805), 1,
-      sym__separator,
-    ACTIONS(807), 1,
-      sym__line_break,
-  [5101] = 3,
+  [5247] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(74), 1,
       anon_sym_FINALLY,
-    ACTIONS(607), 1,
+    ACTIONS(797), 1,
       anon_sym_END,
-  [5111] = 3,
+  [5257] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(515), 1,
+      sym__separator,
+    ACTIONS(517), 1,
+      sym__line_break,
+  [5267] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(799), 1,
+      aux_sym_comments_section_token2,
+    ACTIONS(801), 1,
+      sym__line_break,
+  [5277] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(803), 1,
+      sym__separator,
+    ACTIONS(805), 1,
+      sym__line_break,
+  [5287] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(807), 1,
+      sym__separator,
+    STATE(376), 1,
+      sym__indentation,
+  [5297] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(747), 1,
+      sym__line_break,
+    ACTIONS(809), 1,
+      sym__separator,
+  [5307] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(346), 1,
       anon_sym_DOLLAR_LBRACE,
-    STATE(366), 1,
+    STATE(333), 1,
       sym_scalar_variable,
-  [5121] = 3,
-    ACTIONS(3), 1,
+  [5317] = 3,
+    ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(809), 1,
-      anon_sym_SPACE,
     ACTIONS(811), 1,
-      sym_variable_name,
-  [5131] = 3,
+      sym__separator,
+    STATE(390), 1,
+      sym__indentation,
+  [5327] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(813), 1,
       sym__separator,
-    STATE(228), 1,
+    STATE(282), 1,
       aux_sym_for_statement_repeat1,
-  [5141] = 3,
+  [5337] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(815), 1,
-      anon_sym_SPACE,
+      sym__separator,
     ACTIONS(817), 1,
-      anon_sym_RBRACE,
-  [5151] = 3,
+      sym__line_break,
+  [5347] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(819), 1,
       anon_sym_SPACE,
     ACTIONS(821), 1,
-      anon_sym_RBRACE,
-  [5161] = 3,
+      anon_sym_RBRACK,
+  [5357] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(623), 1,
+      anon_sym_ELSEIF,
+    STATE(265), 1,
+      sym_inline_elseif_statement,
+  [5367] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(823), 1,
-      anon_sym_SPACE,
+      sym__separator,
     ACTIONS(825), 1,
-      anon_sym_RBRACE,
-  [5171] = 3,
+      sym__line_break,
+  [5377] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(827), 1,
-      sym__separator,
+      anon_sym_SPACE,
     ACTIONS(829), 1,
-      sym__line_break,
-  [5181] = 3,
+      anon_sym_RBRACK,
+  [5387] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(831), 1,
       sym__separator,
-    STATE(400), 1,
-      sym__indentation,
-  [5191] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
     ACTIONS(833), 1,
-      anon_sym_SPACE,
-    ACTIONS(835), 1,
-      anon_sym_RBRACK,
-  [5201] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(837), 1,
-      aux_sym_comments_section_token2,
-    ACTIONS(839), 1,
       sym__line_break,
-  [5211] = 3,
+  [5397] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(505), 1,
+    ACTIONS(835), 1,
       sym__separator,
-    ACTIONS(507), 1,
+    ACTIONS(837), 1,
       sym__line_break,
-  [5221] = 3,
+  [5407] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(762), 1,
+      sym__line_break,
+    ACTIONS(839), 1,
+      sym__separator,
+  [5417] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(841), 1,
       sym__separator,
     ACTIONS(843), 1,
       sym__line_break,
-  [5231] = 3,
+  [5427] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(845), 1,
       sym__separator,
     ACTIONS(847), 1,
       sym__line_break,
-  [5241] = 3,
+  [5437] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(849), 1,
-      anon_sym_SPACE,
-    ACTIONS(851), 1,
-      anon_sym_RBRACK,
-  [5251] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(853), 1,
       sym__separator,
-    STATE(377), 1,
+    STATE(351), 1,
       sym__indentation,
-  [5261] = 3,
-    ACTIONS(25), 1,
+  [5447] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(851), 1,
+      anon_sym_SPACE,
+    ACTIONS(853), 1,
+      sym_variable_name,
+  [5457] = 3,
+    ACTIONS(3), 1,
       sym_comment,
     ACTIONS(855), 1,
       anon_sym_SPACE,
     ACTIONS(857), 1,
-      anon_sym_RBRACE,
-  [5271] = 3,
+      sym_variable_name,
+  [5467] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(859), 1,
-      anon_sym_SPACE,
-    ACTIONS(861), 1,
-      anon_sym_RBRACE,
-  [5281] = 3,
+      sym__separator,
+    STATE(282), 1,
+      aux_sym_for_statement_repeat1,
+  [5477] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(863), 1,
+    ACTIONS(862), 1,
       anon_sym_SPACE,
-    ACTIONS(865), 1,
-      anon_sym_RBRACE,
-  [5291] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(88), 1,
-      anon_sym_LBRACK,
-    STATE(360), 1,
-      sym_keyword_setting,
-  [5301] = 3,
+    ACTIONS(864), 1,
+      anon_sym_RBRACK,
+  [5487] = 3,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(867), 1,
-      aux_sym_comments_section_token2,
-    ACTIONS(869), 1,
-      sym__line_break,
-  [5311] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(871), 1,
+    ACTIONS(866), 1,
       anon_sym_SPACE,
-    ACTIONS(873), 1,
-      anon_sym_RBRACE,
-  [5321] = 3,
+    ACTIONS(868), 1,
+      sym_variable_name,
+  [5497] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(875), 1,
-      anon_sym_SPACE,
-    ACTIONS(877), 1,
-      anon_sym_RBRACE,
-  [5331] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(879), 1,
-      anon_sym_SPACE,
-    ACTIONS(881), 1,
-      anon_sym_RBRACE,
-  [5341] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(883), 1,
-      anon_sym_SPACE,
-    ACTIONS(885), 1,
-      anon_sym_RBRACE,
-  [5351] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(887), 1,
-      anon_sym_SPACE,
-    ACTIONS(889), 1,
-      anon_sym_RBRACE,
-  [5361] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(891), 1,
-      anon_sym_SPACE,
-    ACTIONS(893), 1,
-      anon_sym_RBRACE,
-  [5371] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(895), 1,
+    ACTIONS(870), 1,
       sym__separator,
-    STATE(322), 1,
+    ACTIONS(872), 1,
+      sym__line_break,
+  [5507] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(874), 1,
+      anon_sym_SPACE,
+    ACTIONS(876), 1,
+      anon_sym_RBRACK,
+  [5517] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(878), 1,
+      sym__separator,
+    STATE(388), 1,
       sym__indentation,
-  [5381] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(897), 1,
-      anon_sym_SPACE,
-    ACTIONS(899), 1,
-      anon_sym_RBRACE,
-  [5391] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(901), 1,
-      anon_sym_SPACE,
-    ACTIONS(903), 1,
-      anon_sym_RBRACE,
-  [5401] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(905), 1,
-      anon_sym_SPACE,
-    ACTIONS(907), 1,
-      anon_sym_RBRACE,
-  [5411] = 3,
+  [5527] = 3,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(74), 1,
       anon_sym_FINALLY,
-    ACTIONS(614), 1,
+    ACTIONS(608), 1,
       anon_sym_END,
-  [5421] = 3,
-    ACTIONS(3), 1,
+  [5537] = 3,
+    ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(909), 1,
+    ACTIONS(880), 1,
       anon_sym_SPACE,
-    ACTIONS(911), 1,
-      sym_variable_name,
-  [5431] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(913), 1,
-      anon_sym_SPACE,
-    ACTIONS(915), 1,
-      anon_sym_RBRACE,
-  [5441] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(917), 1,
-      anon_sym_SPACE,
-    ACTIONS(919), 1,
-      anon_sym_RBRACE,
-  [5451] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(921), 1,
-      anon_sym_SPACE,
-    ACTIONS(923), 1,
-      anon_sym_RBRACE,
-  [5461] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(925), 1,
-      anon_sym_SPACE,
-    ACTIONS(927), 1,
-      anon_sym_RBRACE,
-  [5471] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(929), 1,
-      anon_sym_SPACE,
-    ACTIONS(931), 1,
-      anon_sym_RBRACE,
-  [5481] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(933), 1,
-      anon_sym_SPACE,
-    ACTIONS(935), 1,
-      anon_sym_RBRACE,
-  [5491] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(937), 1,
-      anon_sym_SPACE,
-    ACTIONS(939), 1,
-      anon_sym_RBRACE,
-  [5501] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(941), 1,
-      anon_sym_SPACE,
-    ACTIONS(943), 1,
-      anon_sym_RBRACE,
-  [5511] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(945), 1,
-      anon_sym_SPACE,
-    ACTIONS(947), 1,
-      sym_variable_name,
-  [5521] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(949), 1,
-      anon_sym_SPACE,
-    ACTIONS(951), 1,
-      sym_variable_name,
-  [5531] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(953), 1,
-      anon_sym_SPACE,
-    ACTIONS(955), 1,
-      sym_variable_name,
-  [5541] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(807), 1,
-      sym__line_break,
-    ACTIONS(957), 1,
-      sym__separator,
-  [5551] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(959), 1,
-      anon_sym_SPACE,
-    ACTIONS(961), 1,
-      sym_variable_name,
-  [5561] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(963), 1,
-      anon_sym_SPACE,
-    ACTIONS(965), 1,
-      sym_variable_name,
-  [5571] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(967), 1,
-      anon_sym_SPACE,
-    ACTIONS(969), 1,
-      sym_variable_name,
-  [5581] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(971), 1,
-      anon_sym_SPACE,
-    ACTIONS(973), 1,
-      sym_variable_name,
-  [5591] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(975), 1,
-      anon_sym_SPACE,
-    ACTIONS(977), 1,
-      sym_variable_name,
-  [5601] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(979), 1,
-      anon_sym_SPACE,
-    ACTIONS(981), 1,
-      sym_variable_name,
-  [5611] = 3,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(983), 1,
-      anon_sym_SPACE,
-    ACTIONS(985), 1,
-      sym_variable_name,
-  [5621] = 3,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(987), 1,
-      sym__separator,
-    ACTIONS(989), 1,
-      sym__line_break,
-  [5631] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(991), 1,
-      sym_variable_name,
-  [5638] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(777), 1,
-      anon_sym_RBRACE,
-  [5645] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(993), 1,
-      sym__line_break,
-  [5652] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(995), 1,
-      sym__line_break,
-  [5659] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(997), 1,
-      anon_sym_RBRACE,
-  [5666] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(999), 1,
-      sym_variable_name,
-  [5673] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1001), 1,
-      sym__line_break,
-  [5680] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(94), 1,
-      sym_ellipses,
-  [5687] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1003), 1,
-      sym__line_break,
-  [5694] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(744), 1,
-      anon_sym_END,
-  [5701] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1005), 1,
-      sym__line_break,
-  [5708] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1007), 1,
-      sym__line_break,
-  [5715] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1009), 1,
-      sym_variable_name,
-  [5722] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1011), 1,
-      sym_variable_name,
-  [5729] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1013), 1,
-      sym__separator,
-  [5736] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1015), 1,
-      sym__separator,
-  [5743] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1017), 1,
-      sym__separator,
-  [5750] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1019), 1,
-      sym__line_break,
-  [5757] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1021), 1,
-      sym__line_break,
-  [5764] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(797), 1,
-      anon_sym_RBRACE,
-  [5771] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1023), 1,
-      sym__line_break,
-  [5778] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1025), 1,
-      sym__line_break,
-  [5785] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1027), 1,
-      sym__line_break,
-  [5792] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1029), 1,
-      sym__separator,
-  [5799] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(607), 1,
-      anon_sym_END,
-  [5806] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1031), 1,
-      sym_variable_name,
-  [5813] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1033), 1,
-      sym__line_break,
-  [5820] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1035), 1,
-      sym__line_break,
-  [5827] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1037), 1,
+    ACTIONS(882), 1,
       anon_sym_RBRACK,
-  [5834] = 2,
+  [5547] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1039), 1,
+    ACTIONS(884), 1,
+      sym__separator,
+    ACTIONS(886), 1,
       sym__line_break,
-  [5841] = 2,
-    ACTIONS(25), 1,
+  [5557] = 3,
+    ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(1041), 1,
+    ACTIONS(888), 1,
+      aux_sym_comments_section_token2,
+    ACTIONS(890), 1,
       sym__line_break,
-  [5848] = 2,
+  [5567] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1043), 1,
-      sym__line_break,
-  [5855] = 2,
+    ACTIONS(892), 1,
+      sym__separator,
+    STATE(418), 1,
+      sym__indentation,
+  [5577] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1045), 1,
-      sym__line_break,
-  [5862] = 2,
+    ACTIONS(894), 1,
+      sym__separator,
+    STATE(268), 1,
+      aux_sym_for_statement_repeat1,
+  [5587] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(825), 1,
+    ACTIONS(896), 1,
+      anon_sym_SPACE,
+    ACTIONS(898), 1,
       anon_sym_RBRACE,
-  [5869] = 2,
+  [5597] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(900), 1,
+      anon_sym_SPACE,
+    ACTIONS(902), 1,
+      sym_variable_name,
+  [5607] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1047), 1,
-      sym__line_break,
-  [5876] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1049), 1,
-      sym__line_break,
-  [5883] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1051), 1,
-      sym__line_break,
-  [5890] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1053), 1,
+    ACTIONS(904), 1,
       sym__separator,
-  [5897] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1055), 1,
+    ACTIONS(906), 1,
       sym__line_break,
-  [5904] = 2,
+  [5617] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1057), 1,
+    ACTIONS(908), 1,
       sym__separator,
-  [5911] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1059), 1,
-      ts_builtin_sym_end,
-  [5918] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1061), 1,
-      sym__separator,
-  [5925] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(569), 1,
-      sym__separator,
-  [5932] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1063), 1,
+    ACTIONS(910), 1,
       sym__line_break,
-  [5939] = 2,
+  [5627] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1065), 1,
-      sym__line_break,
-  [5946] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(519), 1,
+    ACTIONS(912), 1,
       sym__separator,
-  [5953] = 2,
+    STATE(406), 1,
+      sym__indentation,
+  [5637] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1067), 1,
+    ACTIONS(914), 1,
+      anon_sym_SPACE,
+    ACTIONS(916), 1,
+      anon_sym_RBRACE,
+  [5647] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(918), 1,
+      anon_sym_SPACE,
+    ACTIONS(920), 1,
+      anon_sym_RBRACE,
+  [5657] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(922), 1,
+      anon_sym_SPACE,
+    ACTIONS(924), 1,
+      anon_sym_RBRACE,
+  [5667] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(926), 1,
+      sym__separator,
+    STATE(464), 1,
+      sym__indentation,
+  [5677] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(928), 1,
+      anon_sym_SPACE,
+    ACTIONS(930), 1,
+      anon_sym_RBRACE,
+  [5687] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(932), 1,
+      anon_sym_SPACE,
+    ACTIONS(934), 1,
+      anon_sym_RBRACE,
+  [5697] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(936), 1,
+      anon_sym_SPACE,
+    ACTIONS(938), 1,
+      anon_sym_RBRACE,
+  [5707] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(940), 1,
+      aux_sym_comments_section_token2,
+    ACTIONS(942), 1,
+      sym__line_break,
+  [5717] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(944), 1,
+      anon_sym_SPACE,
+    ACTIONS(946), 1,
+      anon_sym_RBRACE,
+  [5727] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(948), 1,
+      anon_sym_SPACE,
+    ACTIONS(950), 1,
+      anon_sym_RBRACE,
+  [5737] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(952), 1,
+      anon_sym_SPACE,
+    ACTIONS(954), 1,
+      anon_sym_RBRACE,
+  [5747] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(956), 1,
+      anon_sym_SPACE,
+    ACTIONS(958), 1,
+      anon_sym_RBRACE,
+  [5757] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(960), 1,
+      aux_sym_comments_section_token2,
+    ACTIONS(962), 1,
+      sym__line_break,
+  [5767] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(964), 1,
+      anon_sym_SPACE,
+    ACTIONS(966), 1,
+      anon_sym_RBRACE,
+  [5777] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(968), 1,
+      anon_sym_SPACE,
+    ACTIONS(970), 1,
+      anon_sym_RBRACE,
+  [5787] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(972), 1,
+      anon_sym_SPACE,
+    ACTIONS(974), 1,
+      anon_sym_RBRACE,
+  [5797] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(976), 1,
+      anon_sym_SPACE,
+    ACTIONS(978), 1,
+      anon_sym_RBRACE,
+  [5807] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(980), 1,
+      sym__separator,
+    ACTIONS(982), 1,
+      sym__line_break,
+  [5817] = 3,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(984), 1,
+      anon_sym_SPACE,
+    ACTIONS(986), 1,
       anon_sym_RBRACK,
-  [5960] = 2,
+  [5827] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(988), 1,
+      anon_sym_SPACE,
+    ACTIONS(990), 1,
+      sym_variable_name,
+  [5837] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(992), 1,
+      anon_sym_SPACE,
+    ACTIONS(994), 1,
+      sym_variable_name,
+  [5847] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(996), 1,
+      anon_sym_SPACE,
+    ACTIONS(998), 1,
+      sym_variable_name,
+  [5857] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1069), 1,
+    ACTIONS(886), 1,
       sym__line_break,
-  [5967] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(537), 1,
+    ACTIONS(1000), 1,
       sym__separator,
-  [5974] = 2,
+  [5867] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1071), 1,
-      sym__line_break,
-  [5981] = 2,
+    ACTIONS(88), 1,
+      anon_sym_LBRACK,
+    STATE(411), 1,
+      sym_keyword_setting,
+  [5877] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1002), 1,
+      anon_sym_SPACE,
+    ACTIONS(1004), 1,
+      sym_variable_name,
+  [5887] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1006), 1,
+      anon_sym_SPACE,
+    ACTIONS(1008), 1,
+      sym_variable_name,
+  [5897] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1010), 1,
+      anon_sym_SPACE,
+    ACTIONS(1012), 1,
+      sym_variable_name,
+  [5907] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1014), 1,
+      anon_sym_SPACE,
+    ACTIONS(1016), 1,
+      sym_variable_name,
+  [5917] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1018), 1,
+      anon_sym_SPACE,
+    ACTIONS(1020), 1,
+      sym_variable_name,
+  [5927] = 3,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1022), 1,
+      anon_sym_SPACE,
+    ACTIONS(1024), 1,
+      sym_variable_name,
+  [5937] = 3,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1073), 1,
-      sym__line_break,
-  [5988] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1075), 1,
-      sym__line_break,
-  [5995] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1077), 1,
-      sym__line_break,
-  [6002] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1079), 1,
-      sym__separator,
-  [6009] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1081), 1,
-      sym__line_break,
-  [6016] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1083), 1,
-      sym__line_break,
-  [6023] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1085), 1,
-      sym__separator,
-  [6030] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1087), 1,
-      sym__line_break,
-  [6037] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1089), 1,
-      anon_sym_END,
-  [6044] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1091), 1,
-      sym__line_break,
-  [6051] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1093), 1,
-      sym__line_break,
-  [6058] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(72), 1,
-      anon_sym_EXCEPT,
-  [6065] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1095), 1,
-      sym_ellipses,
-  [6072] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1097), 1,
-      sym__line_break,
-  [6079] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1099), 1,
-      anon_sym_END,
-  [6086] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1101), 1,
-      anon_sym_END,
-  [6093] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(873), 1,
+    ACTIONS(1026), 1,
+      anon_sym_SPACE,
+    ACTIONS(1028), 1,
       anon_sym_RBRACE,
-  [6100] = 2,
+  [5947] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1030), 1,
+      sym_variable_name,
+  [5954] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1103), 1,
+    ACTIONS(1032), 1,
       sym__line_break,
-  [6107] = 2,
+  [5961] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(877), 1,
+    ACTIONS(1034), 1,
       anon_sym_RBRACE,
-  [6114] = 2,
+  [5968] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1036), 1,
+      sym__separator,
+  [5975] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1038), 1,
+      sym__line_break,
+  [5982] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1040), 1,
+      sym__line_break,
+  [5989] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1042), 1,
+      sym__line_break,
+  [5996] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1044), 1,
+      anon_sym_RBRACK,
+  [6003] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1046), 1,
+      anon_sym_RBRACE,
+  [6010] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1048), 1,
+      anon_sym_END,
+  [6017] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1050), 1,
+      sym__line_break,
+  [6024] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1052), 1,
+      sym__line_break,
+  [6031] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1054), 1,
+      sym__line_break,
+  [6038] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1056), 1,
+      sym__line_break,
+  [6045] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1058), 1,
+      sym__separator,
+  [6052] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1060), 1,
+      sym_variable_name,
+  [6059] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1062), 1,
+      sym__separator,
+  [6066] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1064), 1,
+      sym__line_break,
+  [6073] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1066), 1,
+      anon_sym_END,
+  [6080] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(637), 1,
+      anon_sym_RBRACE,
+  [6087] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1068), 1,
+      sym__line_break,
+  [6094] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(608), 1,
+      anon_sym_END,
+  [6101] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1070), 1,
+      sym__line_break,
+  [6108] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1072), 1,
+      sym__line_break,
+  [6115] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1074), 1,
+      sym_variable_name,
+  [6122] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1076), 1,
+      sym__line_break,
+  [6129] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1078), 1,
+      sym__line_break,
+  [6136] = 2,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(84), 1,
       anon_sym_ELSEIF,
-  [6121] = 2,
+  [6143] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(881), 1,
+    ACTIONS(1080), 1,
+      sym__separator,
+  [6150] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1082), 1,
+      sym__line_break,
+  [6157] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1084), 1,
+      sym__line_break,
+  [6164] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1086), 1,
+      sym_variable_name,
+  [6171] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1088), 1,
+      anon_sym_END,
+  [6178] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1090), 1,
+      sym__separator,
+  [6185] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1092), 1,
+      sym__line_break,
+  [6192] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(523), 1,
+      sym__separator,
+  [6199] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1094), 1,
+      sym__line_break,
+  [6206] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1096), 1,
+      sym__line_break,
+  [6213] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(535), 1,
+      sym__separator,
+  [6220] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1098), 1,
+      anon_sym_RBRACK,
+  [6227] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1100), 1,
+      sym__separator,
+  [6234] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(555), 1,
+      sym__separator,
+  [6241] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1102), 1,
+      sym__separator,
+  [6248] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1104), 1,
+      sym__line_break,
+  [6255] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(567), 1,
+      sym__separator,
+  [6262] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1106), 1,
+      sym__line_break,
+  [6269] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1108), 1,
+      anon_sym_END,
+  [6276] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1110), 1,
+      sym__line_break,
+  [6283] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1028), 1,
       anon_sym_RBRACE,
-  [6128] = 2,
+  [6290] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1112), 1,
+      sym__separator,
+  [6297] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1114), 1,
+      sym__line_break,
+  [6304] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1116), 1,
+      sym__line_break,
+  [6311] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1118), 1,
+      sym__line_break,
+  [6318] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1120), 1,
+      sym_variable_name,
+  [6325] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1122), 1,
+      sym__line_break,
+  [6332] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1124), 1,
+      anon_sym_RBRACE,
+  [6339] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1126), 1,
+      sym__line_break,
+  [6346] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1128), 1,
+      sym_ellipses,
+  [6353] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(610), 1,
+      anon_sym_END,
+  [6360] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1130), 1,
+      sym__line_break,
+  [6367] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1132), 1,
+      anon_sym_END,
+  [6374] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(669), 1,
+      anon_sym_RBRACE,
+  [6381] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(924), 1,
+      anon_sym_RBRACE,
+  [6388] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1134), 1,
+      sym__line_break,
+  [6395] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(930), 1,
+      anon_sym_RBRACE,
+  [6402] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1136), 1,
+      sym__line_break,
+  [6409] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(934), 1,
+      anon_sym_RBRACE,
+  [6416] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1138), 1,
+      sym__line_break,
+  [6423] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1140), 1,
+      sym__line_break,
+  [6430] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(675), 1,
+      anon_sym_RBRACE,
+  [6437] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1142), 1,
+      sym__line_break,
+  [6444] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1144), 1,
+      anon_sym_RBRACE,
+  [6451] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1146), 1,
+      anon_sym_RBRACE,
+  [6458] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1148), 1,
+      anon_sym_RBRACE,
+  [6465] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1150), 1,
+      sym__line_break,
+  [6472] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1152), 1,
+      anon_sym_RBRACE,
+  [6479] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1154), 1,
+      anon_sym_END,
+  [6486] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1156), 1,
+      sym__line_break,
+  [6493] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1158), 1,
+      sym__separator,
+  [6500] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1160), 1,
+      sym__line_break,
+  [6507] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1162), 1,
+      anon_sym_RBRACE,
+  [6514] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1164), 1,
+      sym__line_break,
+  [6521] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(602), 1,
+      anon_sym_RBRACE,
+  [6528] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(72), 1,
+      anon_sym_EXCEPT,
+  [6535] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1166), 1,
+      sym__separator,
+  [6542] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(954), 1,
+      anon_sym_RBRACE,
+  [6549] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1168), 1,
+      sym__line_break,
+  [6556] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(958), 1,
+      anon_sym_RBRACE,
+  [6563] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1170), 1,
+      anon_sym_END,
+  [6570] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1172), 1,
+      sym__line_break,
+  [6577] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(692), 1,
+      anon_sym_RBRACE,
+  [6584] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1174), 1,
+      sym__line_break,
+  [6591] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1176), 1,
+      anon_sym_RBRACE,
+  [6598] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1178), 1,
+      anon_sym_RBRACE,
+  [6605] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1180), 1,
+      anon_sym_RBRACE,
+  [6612] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1182), 1,
+      sym__line_break,
+  [6619] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1184), 1,
+      sym__line_break,
+  [6626] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1186), 1,
+      sym__line_break,
+  [6633] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1188), 1,
+      sym__line_break,
+  [6640] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1190), 1,
+      sym__line_break,
+  [6647] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(700), 1,
+      anon_sym_RBRACE,
+  [6654] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1192), 1,
+      sym__line_break,
+  [6661] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1194), 1,
+      sym__line_break,
+  [6668] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(974), 1,
+      anon_sym_RBRACE,
+  [6675] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1196), 1,
+      sym__separator,
+  [6682] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(978), 1,
+      anon_sym_RBRACE,
+  [6689] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(704), 1,
+      anon_sym_RBRACE,
+  [6696] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1198), 1,
+      sym__line_break,
+  [6703] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1200), 1,
+      anon_sym_RBRACE,
+  [6710] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1202), 1,
+      anon_sym_RBRACE,
+  [6717] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1204), 1,
+      anon_sym_RBRACE,
+  [6724] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1206), 1,
+      sym__line_break,
+  [6731] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1208), 1,
+      sym__line_break,
+  [6738] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1210), 1,
+      sym__line_break,
+  [6745] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(712), 1,
+      anon_sym_RBRACE,
+  [6752] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1212), 1,
+      sym__line_break,
+  [6759] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(606), 1,
+      anon_sym_RBRACE,
+  [6766] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1214), 1,
+      anon_sym_RBRACK,
+  [6773] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1216), 1,
+      anon_sym_RBRACE,
+  [6780] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1218), 1,
+      anon_sym_RBRACK,
+  [6787] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1220), 1,
+      sym__line_break,
+  [6794] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1222), 1,
+      sym__line_break,
+  [6801] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1224), 1,
+      sym_variable_name,
+  [6808] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1226), 1,
+      sym_variable_name,
+  [6815] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1228), 1,
+      sym_variable_name,
+  [6822] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1230), 1,
+      sym__line_break,
+  [6829] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1232), 1,
+      sym__separator,
+  [6836] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1234), 1,
+      ts_builtin_sym_end,
+  [6843] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1236), 1,
+      sym__separator,
+  [6850] = 2,
     ACTIONS(25), 1,
       sym_comment,
     ACTIONS(614), 1,
+      anon_sym_RBRACE,
+  [6857] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1238), 1,
+      sym_variable_name,
+  [6864] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1240), 1,
+      sym_variable_name,
+  [6871] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1242), 1,
+      sym_variable_name,
+  [6878] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(1244), 1,
+      sym__line_break,
+  [6885] = 2,
+    ACTIONS(25), 1,
+      sym_comment,
+    ACTIONS(797), 1,
       anon_sym_END,
-  [6135] = 2,
+  [6892] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1105), 1,
-      sym__line_break,
-  [6142] = 2,
+    ACTIONS(94), 1,
+      sym_ellipses,
+  [6899] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1246), 1,
+      sym_variable_name,
+  [6906] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1248), 1,
+      sym_variable_name,
+  [6913] = 2,
+    ACTIONS(3), 1,
+      sym_comment,
+    ACTIONS(1250), 1,
+      sym_variable_name,
+  [6920] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1107), 1,
-      anon_sym_RBRACE,
-  [6149] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1109), 1,
-      anon_sym_RBRACE,
-  [6156] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1111), 1,
-      anon_sym_RBRACE,
-  [6163] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1113), 1,
-      sym__line_break,
-  [6170] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1115), 1,
-      anon_sym_RBRACE,
-  [6177] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1117), 1,
-      sym__line_break,
-  [6184] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1119), 1,
-      sym__line_break,
-  [6191] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1121), 1,
-      anon_sym_END,
-  [6198] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1123), 1,
-      sym__separator,
-  [6205] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1125), 1,
-      sym__line_break,
-  [6212] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1127), 1,
-      anon_sym_END,
-  [6219] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(899), 1,
-      anon_sym_RBRACE,
-  [6226] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1129), 1,
+    ACTIONS(1252), 1,
       anon_sym_RBRACK,
-  [6233] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(903), 1,
-      anon_sym_RBRACE,
-  [6240] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1131), 1,
-      anon_sym_END,
-  [6247] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(907), 1,
-      anon_sym_RBRACE,
-  [6254] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1133), 1,
-      sym__line_break,
-  [6261] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1135), 1,
-      sym__line_break,
-  [6268] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1137), 1,
-      anon_sym_RBRACE,
-  [6275] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1139), 1,
-      anon_sym_RBRACE,
-  [6282] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1141), 1,
-      anon_sym_RBRACE,
-  [6289] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1143), 1,
-      sym__line_break,
-  [6296] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1145), 1,
-      sym__line_break,
-  [6303] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1147), 1,
-      anon_sym_END,
-  [6310] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1149), 1,
-      sym__line_break,
-  [6317] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1151), 1,
-      sym__line_break,
-  [6324] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(927), 1,
-      anon_sym_RBRACE,
-  [6331] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1153), 1,
-      sym__line_break,
-  [6338] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(931), 1,
-      anon_sym_RBRACE,
-  [6345] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1155), 1,
-      sym__line_break,
-  [6352] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(935), 1,
-      anon_sym_RBRACE,
-  [6359] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1157), 1,
-      anon_sym_RBRACE,
-  [6366] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1159), 1,
-      anon_sym_RBRACE,
-  [6373] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1161), 1,
-      anon_sym_RBRACE,
-  [6380] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1163), 1,
-      sym__line_break,
-  [6387] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1165), 1,
-      sym__line_break,
-  [6394] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1167), 1,
-      sym__line_break,
-  [6401] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(943), 1,
-      anon_sym_RBRACE,
-  [6408] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1169), 1,
-      anon_sym_RBRACE,
-  [6415] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1171), 1,
-      sym__separator,
-  [6422] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1173), 1,
-      sym__line_break,
-  [6429] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1175), 1,
-      sym__line_break,
-  [6436] = 2,
+  [6927] = 2,
     ACTIONS(3), 1,
       sym_comment,
-    ACTIONS(1177), 1,
+    ACTIONS(1254), 1,
       sym_variable_name,
-  [6443] = 2,
+  [6934] = 2,
     ACTIONS(25), 1,
       sym_comment,
-    ACTIONS(1179), 1,
-      anon_sym_RBRACK,
-  [6450] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1181), 1,
-      sym_variable_name,
-  [6457] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1183), 1,
-      anon_sym_RBRACE,
-  [6464] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1185), 1,
-      sym_variable_name,
-  [6471] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1187), 1,
-      sym__line_break,
-  [6478] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1189), 1,
-      anon_sym_RBRACE,
-  [6485] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1191), 1,
-      sym__separator,
-  [6492] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1193), 1,
-      sym_variable_name,
-  [6499] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1195), 1,
-      sym_variable_name,
-  [6506] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1197), 1,
-      sym_variable_name,
-  [6513] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1199), 1,
-      sym__line_break,
-  [6520] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1201), 1,
-      sym__separator,
-  [6527] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1203), 1,
-      sym__line_break,
-  [6534] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1205), 1,
-      sym_variable_name,
-  [6541] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1207), 1,
-      sym_variable_name,
-  [6548] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1209), 1,
-      sym_variable_name,
-  [6555] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1211), 1,
-      anon_sym_RBRACE,
-  [6562] = 2,
-    ACTIONS(3), 1,
-      sym_comment,
-    ACTIONS(1213), 1,
-      sym_variable_name,
-  [6569] = 2,
-    ACTIONS(25), 1,
-      sym_comment,
-    ACTIONS(1215), 1,
+    ACTIONS(1256), 1,
       sym__line_break,
 };
 
@@ -11140,8 +11506,8 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(14)] = 579,
   [SMALL_STATE(15)] = 627,
   [SMALL_STATE(16)] = 672,
-  [SMALL_STATE(17)] = 710,
-  [SMALL_STATE(18)] = 748,
+  [SMALL_STATE(17)] = 714,
+  [SMALL_STATE(18)] = 752,
   [SMALL_STATE(19)] = 790,
   [SMALL_STATE(20)] = 828,
   [SMALL_STATE(21)] = 866,
@@ -11151,12 +11517,12 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(25)] = 1009,
   [SMALL_STATE(26)] = 1044,
   [SMALL_STATE(27)] = 1079,
-  [SMALL_STATE(28)] = 1111,
+  [SMALL_STATE(28)] = 1113,
   [SMALL_STATE(29)] = 1145,
   [SMALL_STATE(30)] = 1177,
-  [SMALL_STATE(31)] = 1209,
-  [SMALL_STATE(32)] = 1241,
-  [SMALL_STATE(33)] = 1273,
+  [SMALL_STATE(31)] = 1211,
+  [SMALL_STATE(32)] = 1243,
+  [SMALL_STATE(33)] = 1275,
   [SMALL_STATE(34)] = 1307,
   [SMALL_STATE(35)] = 1339,
   [SMALL_STATE(36)] = 1371,
@@ -11166,21 +11532,21 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(40)] = 1489,
   [SMALL_STATE(41)] = 1509,
   [SMALL_STATE(42)] = 1538,
-  [SMALL_STATE(43)] = 1557,
-  [SMALL_STATE(44)] = 1586,
-  [SMALL_STATE(45)] = 1615,
-  [SMALL_STATE(46)] = 1648,
-  [SMALL_STATE(47)] = 1667,
-  [SMALL_STATE(48)] = 1686,
-  [SMALL_STATE(49)] = 1707,
-  [SMALL_STATE(50)] = 1736,
-  [SMALL_STATE(51)] = 1757,
-  [SMALL_STATE(52)] = 1786,
-  [SMALL_STATE(53)] = 1807,
-  [SMALL_STATE(54)] = 1836,
-  [SMALL_STATE(55)] = 1857,
-  [SMALL_STATE(56)] = 1886,
-  [SMALL_STATE(57)] = 1915,
+  [SMALL_STATE(43)] = 1559,
+  [SMALL_STATE(44)] = 1580,
+  [SMALL_STATE(45)] = 1601,
+  [SMALL_STATE(46)] = 1630,
+  [SMALL_STATE(47)] = 1659,
+  [SMALL_STATE(48)] = 1692,
+  [SMALL_STATE(49)] = 1711,
+  [SMALL_STATE(50)] = 1730,
+  [SMALL_STATE(51)] = 1751,
+  [SMALL_STATE(52)] = 1772,
+  [SMALL_STATE(53)] = 1801,
+  [SMALL_STATE(54)] = 1830,
+  [SMALL_STATE(55)] = 1859,
+  [SMALL_STATE(56)] = 1888,
+  [SMALL_STATE(57)] = 1917,
   [SMALL_STATE(58)] = 1936,
   [SMALL_STATE(59)] = 1965,
   [SMALL_STATE(60)] = 1997,
@@ -11189,8 +11555,8 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(63)] = 2069,
   [SMALL_STATE(64)] = 2095,
   [SMALL_STATE(65)] = 2113,
-  [SMALL_STATE(66)] = 2131,
-  [SMALL_STATE(67)] = 2149,
+  [SMALL_STATE(66)] = 2139,
+  [SMALL_STATE(67)] = 2157,
   [SMALL_STATE(68)] = 2175,
   [SMALL_STATE(69)] = 2190,
   [SMALL_STATE(70)] = 2215,
@@ -11199,378 +11565,402 @@ static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(73)] = 2290,
   [SMALL_STATE(74)] = 2315,
   [SMALL_STATE(75)] = 2340,
-  [SMALL_STATE(76)] = 2364,
-  [SMALL_STATE(77)] = 2386,
-  [SMALL_STATE(78)] = 2404,
-  [SMALL_STATE(79)] = 2428,
-  [SMALL_STATE(80)] = 2446,
-  [SMALL_STATE(81)] = 2468,
-  [SMALL_STATE(82)] = 2492,
+  [SMALL_STATE(76)] = 2362,
+  [SMALL_STATE(77)] = 2380,
+  [SMALL_STATE(78)] = 2406,
+  [SMALL_STATE(79)] = 2424,
+  [SMALL_STATE(80)] = 2448,
+  [SMALL_STATE(81)] = 2472,
+  [SMALL_STATE(82)] = 2494,
   [SMALL_STATE(83)] = 2518,
-  [SMALL_STATE(84)] = 2540,
-  [SMALL_STATE(85)] = 2564,
-  [SMALL_STATE(86)] = 2588,
+  [SMALL_STATE(84)] = 2542,
+  [SMALL_STATE(85)] = 2566,
+  [SMALL_STATE(86)] = 2590,
   [SMALL_STATE(87)] = 2612,
   [SMALL_STATE(88)] = 2634,
   [SMALL_STATE(89)] = 2656,
   [SMALL_STATE(90)] = 2679,
   [SMALL_STATE(91)] = 2702,
-  [SMALL_STATE(92)] = 2717,
-  [SMALL_STATE(93)] = 2740,
-  [SMALL_STATE(94)] = 2763,
-  [SMALL_STATE(95)] = 2786,
-  [SMALL_STATE(96)] = 2809,
-  [SMALL_STATE(97)] = 2832,
-  [SMALL_STATE(98)] = 2855,
-  [SMALL_STATE(99)] = 2878,
-  [SMALL_STATE(100)] = 2893,
+  [SMALL_STATE(92)] = 2725,
+  [SMALL_STATE(93)] = 2748,
+  [SMALL_STATE(94)] = 2761,
+  [SMALL_STATE(95)] = 2784,
+  [SMALL_STATE(96)] = 2807,
+  [SMALL_STATE(97)] = 2830,
+  [SMALL_STATE(98)] = 2845,
+  [SMALL_STATE(99)] = 2860,
+  [SMALL_STATE(100)] = 2883,
   [SMALL_STATE(101)] = 2906,
   [SMALL_STATE(102)] = 2926,
   [SMALL_STATE(103)] = 2946,
   [SMALL_STATE(104)] = 2966,
-  [SMALL_STATE(105)] = 2986,
-  [SMALL_STATE(106)] = 3000,
-  [SMALL_STATE(107)] = 3020,
-  [SMALL_STATE(108)] = 3034,
-  [SMALL_STATE(109)] = 3054,
-  [SMALL_STATE(110)] = 3074,
-  [SMALL_STATE(111)] = 3094,
-  [SMALL_STATE(112)] = 3114,
-  [SMALL_STATE(113)] = 3134,
-  [SMALL_STATE(114)] = 3154,
-  [SMALL_STATE(115)] = 3174,
-  [SMALL_STATE(116)] = 3188,
-  [SMALL_STATE(117)] = 3208,
-  [SMALL_STATE(118)] = 3228,
-  [SMALL_STATE(119)] = 3242,
-  [SMALL_STATE(120)] = 3256,
-  [SMALL_STATE(121)] = 3276,
-  [SMALL_STATE(122)] = 3290,
-  [SMALL_STATE(123)] = 3304,
-  [SMALL_STATE(124)] = 3318,
-  [SMALL_STATE(125)] = 3338,
-  [SMALL_STATE(126)] = 3358,
-  [SMALL_STATE(127)] = 3372,
-  [SMALL_STATE(128)] = 3386,
-  [SMALL_STATE(129)] = 3400,
-  [SMALL_STATE(130)] = 3420,
-  [SMALL_STATE(131)] = 3440,
-  [SMALL_STATE(132)] = 3454,
-  [SMALL_STATE(133)] = 3474,
-  [SMALL_STATE(134)] = 3492,
-  [SMALL_STATE(135)] = 3512,
-  [SMALL_STATE(136)] = 3532,
-  [SMALL_STATE(137)] = 3550,
-  [SMALL_STATE(138)] = 3570,
-  [SMALL_STATE(139)] = 3588,
-  [SMALL_STATE(140)] = 3602,
-  [SMALL_STATE(141)] = 3621,
-  [SMALL_STATE(142)] = 3634,
-  [SMALL_STATE(143)] = 3647,
-  [SMALL_STATE(144)] = 3666,
-  [SMALL_STATE(145)] = 3679,
-  [SMALL_STATE(146)] = 3698,
-  [SMALL_STATE(147)] = 3715,
-  [SMALL_STATE(148)] = 3728,
-  [SMALL_STATE(149)] = 3741,
-  [SMALL_STATE(150)] = 3754,
-  [SMALL_STATE(151)] = 3767,
-  [SMALL_STATE(152)] = 3780,
-  [SMALL_STATE(153)] = 3793,
-  [SMALL_STATE(154)] = 3806,
-  [SMALL_STATE(155)] = 3819,
-  [SMALL_STATE(156)] = 3832,
-  [SMALL_STATE(157)] = 3845,
-  [SMALL_STATE(158)] = 3858,
-  [SMALL_STATE(159)] = 3871,
-  [SMALL_STATE(160)] = 3884,
-  [SMALL_STATE(161)] = 3897,
-  [SMALL_STATE(162)] = 3910,
-  [SMALL_STATE(163)] = 3923,
-  [SMALL_STATE(164)] = 3936,
-  [SMALL_STATE(165)] = 3949,
-  [SMALL_STATE(166)] = 3962,
-  [SMALL_STATE(167)] = 3975,
-  [SMALL_STATE(168)] = 3988,
-  [SMALL_STATE(169)] = 4001,
-  [SMALL_STATE(170)] = 4014,
-  [SMALL_STATE(171)] = 4027,
-  [SMALL_STATE(172)] = 4040,
-  [SMALL_STATE(173)] = 4057,
-  [SMALL_STATE(174)] = 4073,
-  [SMALL_STATE(175)] = 4087,
-  [SMALL_STATE(176)] = 4103,
-  [SMALL_STATE(177)] = 4115,
-  [SMALL_STATE(178)] = 4127,
-  [SMALL_STATE(179)] = 4139,
-  [SMALL_STATE(180)] = 4153,
+  [SMALL_STATE(105)] = 2984,
+  [SMALL_STATE(106)] = 3004,
+  [SMALL_STATE(107)] = 3024,
+  [SMALL_STATE(108)] = 3044,
+  [SMALL_STATE(109)] = 3064,
+  [SMALL_STATE(110)] = 3084,
+  [SMALL_STATE(111)] = 3104,
+  [SMALL_STATE(112)] = 3124,
+  [SMALL_STATE(113)] = 3144,
+  [SMALL_STATE(114)] = 3164,
+  [SMALL_STATE(115)] = 3184,
+  [SMALL_STATE(116)] = 3198,
+  [SMALL_STATE(117)] = 3218,
+  [SMALL_STATE(118)] = 3238,
+  [SMALL_STATE(119)] = 3258,
+  [SMALL_STATE(120)] = 3276,
+  [SMALL_STATE(121)] = 3296,
+  [SMALL_STATE(122)] = 3316,
+  [SMALL_STATE(123)] = 3336,
+  [SMALL_STATE(124)] = 3356,
+  [SMALL_STATE(125)] = 3370,
+  [SMALL_STATE(126)] = 3384,
+  [SMALL_STATE(127)] = 3398,
+  [SMALL_STATE(128)] = 3412,
+  [SMALL_STATE(129)] = 3426,
+  [SMALL_STATE(130)] = 3440,
+  [SMALL_STATE(131)] = 3454,
+  [SMALL_STATE(132)] = 3468,
+  [SMALL_STATE(133)] = 3488,
+  [SMALL_STATE(134)] = 3502,
+  [SMALL_STATE(135)] = 3516,
+  [SMALL_STATE(136)] = 3530,
+  [SMALL_STATE(137)] = 3544,
+  [SMALL_STATE(138)] = 3558,
+  [SMALL_STATE(139)] = 3578,
+  [SMALL_STATE(140)] = 3596,
+  [SMALL_STATE(141)] = 3616,
+  [SMALL_STATE(142)] = 3629,
+  [SMALL_STATE(143)] = 3642,
+  [SMALL_STATE(144)] = 3655,
+  [SMALL_STATE(145)] = 3668,
+  [SMALL_STATE(146)] = 3687,
+  [SMALL_STATE(147)] = 3700,
+  [SMALL_STATE(148)] = 3713,
+  [SMALL_STATE(149)] = 3726,
+  [SMALL_STATE(150)] = 3739,
+  [SMALL_STATE(151)] = 3758,
+  [SMALL_STATE(152)] = 3771,
+  [SMALL_STATE(153)] = 3784,
+  [SMALL_STATE(154)] = 3797,
+  [SMALL_STATE(155)] = 3810,
+  [SMALL_STATE(156)] = 3823,
+  [SMALL_STATE(157)] = 3840,
+  [SMALL_STATE(158)] = 3857,
+  [SMALL_STATE(159)] = 3870,
+  [SMALL_STATE(160)] = 3883,
+  [SMALL_STATE(161)] = 3896,
+  [SMALL_STATE(162)] = 3909,
+  [SMALL_STATE(163)] = 3922,
+  [SMALL_STATE(164)] = 3935,
+  [SMALL_STATE(165)] = 3948,
+  [SMALL_STATE(166)] = 3961,
+  [SMALL_STATE(167)] = 3974,
+  [SMALL_STATE(168)] = 3987,
+  [SMALL_STATE(169)] = 4000,
+  [SMALL_STATE(170)] = 4013,
+  [SMALL_STATE(171)] = 4026,
+  [SMALL_STATE(172)] = 4039,
+  [SMALL_STATE(173)] = 4052,
+  [SMALL_STATE(174)] = 4065,
+  [SMALL_STATE(175)] = 4078,
+  [SMALL_STATE(176)] = 4091,
+  [SMALL_STATE(177)] = 4104,
+  [SMALL_STATE(178)] = 4117,
+  [SMALL_STATE(179)] = 4136,
+  [SMALL_STATE(180)] = 4149,
   [SMALL_STATE(181)] = 4165,
   [SMALL_STATE(182)] = 4181,
-  [SMALL_STATE(183)] = 4193,
-  [SMALL_STATE(184)] = 4207,
-  [SMALL_STATE(185)] = 4219,
-  [SMALL_STATE(186)] = 4235,
-  [SMALL_STATE(187)] = 4247,
-  [SMALL_STATE(188)] = 4263,
-  [SMALL_STATE(189)] = 4277,
-  [SMALL_STATE(190)] = 4293,
-  [SMALL_STATE(191)] = 4305,
-  [SMALL_STATE(192)] = 4317,
-  [SMALL_STATE(193)] = 4331,
-  [SMALL_STATE(194)] = 4345,
-  [SMALL_STATE(195)] = 4359,
-  [SMALL_STATE(196)] = 4373,
-  [SMALL_STATE(197)] = 4387,
-  [SMALL_STATE(198)] = 4401,
-  [SMALL_STATE(199)] = 4415,
-  [SMALL_STATE(200)] = 4429,
-  [SMALL_STATE(201)] = 4440,
-  [SMALL_STATE(202)] = 4453,
-  [SMALL_STATE(203)] = 4466,
-  [SMALL_STATE(204)] = 4479,
-  [SMALL_STATE(205)] = 4492,
-  [SMALL_STATE(206)] = 4505,
-  [SMALL_STATE(207)] = 4518,
-  [SMALL_STATE(208)] = 4531,
-  [SMALL_STATE(209)] = 4542,
-  [SMALL_STATE(210)] = 4555,
-  [SMALL_STATE(211)] = 4566,
-  [SMALL_STATE(212)] = 4579,
-  [SMALL_STATE(213)] = 4590,
-  [SMALL_STATE(214)] = 4603,
-  [SMALL_STATE(215)] = 4616,
-  [SMALL_STATE(216)] = 4629,
-  [SMALL_STATE(217)] = 4642,
-  [SMALL_STATE(218)] = 4655,
-  [SMALL_STATE(219)] = 4668,
-  [SMALL_STATE(220)] = 4681,
-  [SMALL_STATE(221)] = 4694,
-  [SMALL_STATE(222)] = 4707,
-  [SMALL_STATE(223)] = 4720,
-  [SMALL_STATE(224)] = 4731,
-  [SMALL_STATE(225)] = 4742,
-  [SMALL_STATE(226)] = 4755,
-  [SMALL_STATE(227)] = 4768,
-  [SMALL_STATE(228)] = 4781,
-  [SMALL_STATE(229)] = 4791,
-  [SMALL_STATE(230)] = 4801,
-  [SMALL_STATE(231)] = 4811,
-  [SMALL_STATE(232)] = 4821,
-  [SMALL_STATE(233)] = 4831,
-  [SMALL_STATE(234)] = 4841,
-  [SMALL_STATE(235)] = 4851,
-  [SMALL_STATE(236)] = 4861,
-  [SMALL_STATE(237)] = 4871,
-  [SMALL_STATE(238)] = 4881,
-  [SMALL_STATE(239)] = 4891,
-  [SMALL_STATE(240)] = 4901,
-  [SMALL_STATE(241)] = 4911,
-  [SMALL_STATE(242)] = 4921,
-  [SMALL_STATE(243)] = 4931,
-  [SMALL_STATE(244)] = 4941,
-  [SMALL_STATE(245)] = 4951,
-  [SMALL_STATE(246)] = 4961,
-  [SMALL_STATE(247)] = 4971,
-  [SMALL_STATE(248)] = 4981,
-  [SMALL_STATE(249)] = 4991,
-  [SMALL_STATE(250)] = 5001,
-  [SMALL_STATE(251)] = 5011,
-  [SMALL_STATE(252)] = 5021,
-  [SMALL_STATE(253)] = 5031,
-  [SMALL_STATE(254)] = 5041,
-  [SMALL_STATE(255)] = 5051,
-  [SMALL_STATE(256)] = 5061,
-  [SMALL_STATE(257)] = 5071,
-  [SMALL_STATE(258)] = 5081,
-  [SMALL_STATE(259)] = 5091,
-  [SMALL_STATE(260)] = 5101,
-  [SMALL_STATE(261)] = 5111,
-  [SMALL_STATE(262)] = 5121,
-  [SMALL_STATE(263)] = 5131,
-  [SMALL_STATE(264)] = 5141,
-  [SMALL_STATE(265)] = 5151,
-  [SMALL_STATE(266)] = 5161,
-  [SMALL_STATE(267)] = 5171,
-  [SMALL_STATE(268)] = 5181,
-  [SMALL_STATE(269)] = 5191,
-  [SMALL_STATE(270)] = 5201,
-  [SMALL_STATE(271)] = 5211,
-  [SMALL_STATE(272)] = 5221,
-  [SMALL_STATE(273)] = 5231,
-  [SMALL_STATE(274)] = 5241,
-  [SMALL_STATE(275)] = 5251,
-  [SMALL_STATE(276)] = 5261,
-  [SMALL_STATE(277)] = 5271,
-  [SMALL_STATE(278)] = 5281,
-  [SMALL_STATE(279)] = 5291,
-  [SMALL_STATE(280)] = 5301,
-  [SMALL_STATE(281)] = 5311,
-  [SMALL_STATE(282)] = 5321,
-  [SMALL_STATE(283)] = 5331,
-  [SMALL_STATE(284)] = 5341,
-  [SMALL_STATE(285)] = 5351,
-  [SMALL_STATE(286)] = 5361,
-  [SMALL_STATE(287)] = 5371,
-  [SMALL_STATE(288)] = 5381,
-  [SMALL_STATE(289)] = 5391,
-  [SMALL_STATE(290)] = 5401,
-  [SMALL_STATE(291)] = 5411,
-  [SMALL_STATE(292)] = 5421,
-  [SMALL_STATE(293)] = 5431,
-  [SMALL_STATE(294)] = 5441,
-  [SMALL_STATE(295)] = 5451,
-  [SMALL_STATE(296)] = 5461,
-  [SMALL_STATE(297)] = 5471,
-  [SMALL_STATE(298)] = 5481,
-  [SMALL_STATE(299)] = 5491,
-  [SMALL_STATE(300)] = 5501,
-  [SMALL_STATE(301)] = 5511,
-  [SMALL_STATE(302)] = 5521,
-  [SMALL_STATE(303)] = 5531,
-  [SMALL_STATE(304)] = 5541,
-  [SMALL_STATE(305)] = 5551,
-  [SMALL_STATE(306)] = 5561,
-  [SMALL_STATE(307)] = 5571,
-  [SMALL_STATE(308)] = 5581,
-  [SMALL_STATE(309)] = 5591,
-  [SMALL_STATE(310)] = 5601,
-  [SMALL_STATE(311)] = 5611,
-  [SMALL_STATE(312)] = 5621,
-  [SMALL_STATE(313)] = 5631,
-  [SMALL_STATE(314)] = 5638,
-  [SMALL_STATE(315)] = 5645,
-  [SMALL_STATE(316)] = 5652,
-  [SMALL_STATE(317)] = 5659,
-  [SMALL_STATE(318)] = 5666,
-  [SMALL_STATE(319)] = 5673,
-  [SMALL_STATE(320)] = 5680,
-  [SMALL_STATE(321)] = 5687,
-  [SMALL_STATE(322)] = 5694,
-  [SMALL_STATE(323)] = 5701,
-  [SMALL_STATE(324)] = 5708,
-  [SMALL_STATE(325)] = 5715,
-  [SMALL_STATE(326)] = 5722,
-  [SMALL_STATE(327)] = 5729,
-  [SMALL_STATE(328)] = 5736,
-  [SMALL_STATE(329)] = 5743,
-  [SMALL_STATE(330)] = 5750,
-  [SMALL_STATE(331)] = 5757,
-  [SMALL_STATE(332)] = 5764,
-  [SMALL_STATE(333)] = 5771,
-  [SMALL_STATE(334)] = 5778,
-  [SMALL_STATE(335)] = 5785,
-  [SMALL_STATE(336)] = 5792,
-  [SMALL_STATE(337)] = 5799,
-  [SMALL_STATE(338)] = 5806,
-  [SMALL_STATE(339)] = 5813,
-  [SMALL_STATE(340)] = 5820,
-  [SMALL_STATE(341)] = 5827,
-  [SMALL_STATE(342)] = 5834,
-  [SMALL_STATE(343)] = 5841,
-  [SMALL_STATE(344)] = 5848,
-  [SMALL_STATE(345)] = 5855,
-  [SMALL_STATE(346)] = 5862,
-  [SMALL_STATE(347)] = 5869,
-  [SMALL_STATE(348)] = 5876,
-  [SMALL_STATE(349)] = 5883,
-  [SMALL_STATE(350)] = 5890,
-  [SMALL_STATE(351)] = 5897,
-  [SMALL_STATE(352)] = 5904,
-  [SMALL_STATE(353)] = 5911,
-  [SMALL_STATE(354)] = 5918,
-  [SMALL_STATE(355)] = 5925,
-  [SMALL_STATE(356)] = 5932,
-  [SMALL_STATE(357)] = 5939,
-  [SMALL_STATE(358)] = 5946,
-  [SMALL_STATE(359)] = 5953,
-  [SMALL_STATE(360)] = 5960,
-  [SMALL_STATE(361)] = 5967,
-  [SMALL_STATE(362)] = 5974,
-  [SMALL_STATE(363)] = 5981,
-  [SMALL_STATE(364)] = 5988,
-  [SMALL_STATE(365)] = 5995,
-  [SMALL_STATE(366)] = 6002,
-  [SMALL_STATE(367)] = 6009,
-  [SMALL_STATE(368)] = 6016,
-  [SMALL_STATE(369)] = 6023,
-  [SMALL_STATE(370)] = 6030,
-  [SMALL_STATE(371)] = 6037,
-  [SMALL_STATE(372)] = 6044,
-  [SMALL_STATE(373)] = 6051,
-  [SMALL_STATE(374)] = 6058,
-  [SMALL_STATE(375)] = 6065,
-  [SMALL_STATE(376)] = 6072,
-  [SMALL_STATE(377)] = 6079,
-  [SMALL_STATE(378)] = 6086,
-  [SMALL_STATE(379)] = 6093,
-  [SMALL_STATE(380)] = 6100,
-  [SMALL_STATE(381)] = 6107,
-  [SMALL_STATE(382)] = 6114,
-  [SMALL_STATE(383)] = 6121,
-  [SMALL_STATE(384)] = 6128,
-  [SMALL_STATE(385)] = 6135,
-  [SMALL_STATE(386)] = 6142,
-  [SMALL_STATE(387)] = 6149,
-  [SMALL_STATE(388)] = 6156,
-  [SMALL_STATE(389)] = 6163,
-  [SMALL_STATE(390)] = 6170,
-  [SMALL_STATE(391)] = 6177,
-  [SMALL_STATE(392)] = 6184,
-  [SMALL_STATE(393)] = 6191,
-  [SMALL_STATE(394)] = 6198,
-  [SMALL_STATE(395)] = 6205,
-  [SMALL_STATE(396)] = 6212,
-  [SMALL_STATE(397)] = 6219,
-  [SMALL_STATE(398)] = 6226,
-  [SMALL_STATE(399)] = 6233,
-  [SMALL_STATE(400)] = 6240,
-  [SMALL_STATE(401)] = 6247,
-  [SMALL_STATE(402)] = 6254,
-  [SMALL_STATE(403)] = 6261,
-  [SMALL_STATE(404)] = 6268,
-  [SMALL_STATE(405)] = 6275,
-  [SMALL_STATE(406)] = 6282,
-  [SMALL_STATE(407)] = 6289,
-  [SMALL_STATE(408)] = 6296,
-  [SMALL_STATE(409)] = 6303,
-  [SMALL_STATE(410)] = 6310,
-  [SMALL_STATE(411)] = 6317,
-  [SMALL_STATE(412)] = 6324,
-  [SMALL_STATE(413)] = 6331,
-  [SMALL_STATE(414)] = 6338,
-  [SMALL_STATE(415)] = 6345,
-  [SMALL_STATE(416)] = 6352,
-  [SMALL_STATE(417)] = 6359,
-  [SMALL_STATE(418)] = 6366,
-  [SMALL_STATE(419)] = 6373,
-  [SMALL_STATE(420)] = 6380,
-  [SMALL_STATE(421)] = 6387,
-  [SMALL_STATE(422)] = 6394,
-  [SMALL_STATE(423)] = 6401,
-  [SMALL_STATE(424)] = 6408,
-  [SMALL_STATE(425)] = 6415,
-  [SMALL_STATE(426)] = 6422,
-  [SMALL_STATE(427)] = 6429,
-  [SMALL_STATE(428)] = 6436,
-  [SMALL_STATE(429)] = 6443,
-  [SMALL_STATE(430)] = 6450,
-  [SMALL_STATE(431)] = 6457,
-  [SMALL_STATE(432)] = 6464,
-  [SMALL_STATE(433)] = 6471,
-  [SMALL_STATE(434)] = 6478,
-  [SMALL_STATE(435)] = 6485,
-  [SMALL_STATE(436)] = 6492,
-  [SMALL_STATE(437)] = 6499,
-  [SMALL_STATE(438)] = 6506,
-  [SMALL_STATE(439)] = 6513,
-  [SMALL_STATE(440)] = 6520,
-  [SMALL_STATE(441)] = 6527,
-  [SMALL_STATE(442)] = 6534,
-  [SMALL_STATE(443)] = 6541,
-  [SMALL_STATE(444)] = 6548,
-  [SMALL_STATE(445)] = 6555,
-  [SMALL_STATE(446)] = 6562,
-  [SMALL_STATE(447)] = 6569,
+  [SMALL_STATE(183)] = 4197,
+  [SMALL_STATE(184)] = 4213,
+  [SMALL_STATE(185)] = 4225,
+  [SMALL_STATE(186)] = 4241,
+  [SMALL_STATE(187)] = 4257,
+  [SMALL_STATE(188)] = 4269,
+  [SMALL_STATE(189)] = 4285,
+  [SMALL_STATE(190)] = 4301,
+  [SMALL_STATE(191)] = 4317,
+  [SMALL_STATE(192)] = 4329,
+  [SMALL_STATE(193)] = 4345,
+  [SMALL_STATE(194)] = 4357,
+  [SMALL_STATE(195)] = 4369,
+  [SMALL_STATE(196)] = 4383,
+  [SMALL_STATE(197)] = 4399,
+  [SMALL_STATE(198)] = 4413,
+  [SMALL_STATE(199)] = 4427,
+  [SMALL_STATE(200)] = 4443,
+  [SMALL_STATE(201)] = 4457,
+  [SMALL_STATE(202)] = 4471,
+  [SMALL_STATE(203)] = 4487,
+  [SMALL_STATE(204)] = 4501,
+  [SMALL_STATE(205)] = 4515,
+  [SMALL_STATE(206)] = 4529,
+  [SMALL_STATE(207)] = 4545,
+  [SMALL_STATE(208)] = 4561,
+  [SMALL_STATE(209)] = 4575,
+  [SMALL_STATE(210)] = 4591,
+  [SMALL_STATE(211)] = 4605,
+  [SMALL_STATE(212)] = 4621,
+  [SMALL_STATE(213)] = 4635,
+  [SMALL_STATE(214)] = 4651,
+  [SMALL_STATE(215)] = 4667,
+  [SMALL_STATE(216)] = 4681,
+  [SMALL_STATE(217)] = 4697,
+  [SMALL_STATE(218)] = 4713,
+  [SMALL_STATE(219)] = 4729,
+  [SMALL_STATE(220)] = 4745,
+  [SMALL_STATE(221)] = 4761,
+  [SMALL_STATE(222)] = 4777,
+  [SMALL_STATE(223)] = 4793,
+  [SMALL_STATE(224)] = 4809,
+  [SMALL_STATE(225)] = 4821,
+  [SMALL_STATE(226)] = 4834,
+  [SMALL_STATE(227)] = 4847,
+  [SMALL_STATE(228)] = 4858,
+  [SMALL_STATE(229)] = 4871,
+  [SMALL_STATE(230)] = 4884,
+  [SMALL_STATE(231)] = 4895,
+  [SMALL_STATE(232)] = 4906,
+  [SMALL_STATE(233)] = 4919,
+  [SMALL_STATE(234)] = 4932,
+  [SMALL_STATE(235)] = 4943,
+  [SMALL_STATE(236)] = 4956,
+  [SMALL_STATE(237)] = 4969,
+  [SMALL_STATE(238)] = 4982,
+  [SMALL_STATE(239)] = 4995,
+  [SMALL_STATE(240)] = 5008,
+  [SMALL_STATE(241)] = 5021,
+  [SMALL_STATE(242)] = 5032,
+  [SMALL_STATE(243)] = 5045,
+  [SMALL_STATE(244)] = 5058,
+  [SMALL_STATE(245)] = 5071,
+  [SMALL_STATE(246)] = 5084,
+  [SMALL_STATE(247)] = 5095,
+  [SMALL_STATE(248)] = 5108,
+  [SMALL_STATE(249)] = 5121,
+  [SMALL_STATE(250)] = 5134,
+  [SMALL_STATE(251)] = 5147,
+  [SMALL_STATE(252)] = 5160,
+  [SMALL_STATE(253)] = 5171,
+  [SMALL_STATE(254)] = 5184,
+  [SMALL_STATE(255)] = 5197,
+  [SMALL_STATE(256)] = 5207,
+  [SMALL_STATE(257)] = 5217,
+  [SMALL_STATE(258)] = 5227,
+  [SMALL_STATE(259)] = 5237,
+  [SMALL_STATE(260)] = 5247,
+  [SMALL_STATE(261)] = 5257,
+  [SMALL_STATE(262)] = 5267,
+  [SMALL_STATE(263)] = 5277,
+  [SMALL_STATE(264)] = 5287,
+  [SMALL_STATE(265)] = 5297,
+  [SMALL_STATE(266)] = 5307,
+  [SMALL_STATE(267)] = 5317,
+  [SMALL_STATE(268)] = 5327,
+  [SMALL_STATE(269)] = 5337,
+  [SMALL_STATE(270)] = 5347,
+  [SMALL_STATE(271)] = 5357,
+  [SMALL_STATE(272)] = 5367,
+  [SMALL_STATE(273)] = 5377,
+  [SMALL_STATE(274)] = 5387,
+  [SMALL_STATE(275)] = 5397,
+  [SMALL_STATE(276)] = 5407,
+  [SMALL_STATE(277)] = 5417,
+  [SMALL_STATE(278)] = 5427,
+  [SMALL_STATE(279)] = 5437,
+  [SMALL_STATE(280)] = 5447,
+  [SMALL_STATE(281)] = 5457,
+  [SMALL_STATE(282)] = 5467,
+  [SMALL_STATE(283)] = 5477,
+  [SMALL_STATE(284)] = 5487,
+  [SMALL_STATE(285)] = 5497,
+  [SMALL_STATE(286)] = 5507,
+  [SMALL_STATE(287)] = 5517,
+  [SMALL_STATE(288)] = 5527,
+  [SMALL_STATE(289)] = 5537,
+  [SMALL_STATE(290)] = 5547,
+  [SMALL_STATE(291)] = 5557,
+  [SMALL_STATE(292)] = 5567,
+  [SMALL_STATE(293)] = 5577,
+  [SMALL_STATE(294)] = 5587,
+  [SMALL_STATE(295)] = 5597,
+  [SMALL_STATE(296)] = 5607,
+  [SMALL_STATE(297)] = 5617,
+  [SMALL_STATE(298)] = 5627,
+  [SMALL_STATE(299)] = 5637,
+  [SMALL_STATE(300)] = 5647,
+  [SMALL_STATE(301)] = 5657,
+  [SMALL_STATE(302)] = 5667,
+  [SMALL_STATE(303)] = 5677,
+  [SMALL_STATE(304)] = 5687,
+  [SMALL_STATE(305)] = 5697,
+  [SMALL_STATE(306)] = 5707,
+  [SMALL_STATE(307)] = 5717,
+  [SMALL_STATE(308)] = 5727,
+  [SMALL_STATE(309)] = 5737,
+  [SMALL_STATE(310)] = 5747,
+  [SMALL_STATE(311)] = 5757,
+  [SMALL_STATE(312)] = 5767,
+  [SMALL_STATE(313)] = 5777,
+  [SMALL_STATE(314)] = 5787,
+  [SMALL_STATE(315)] = 5797,
+  [SMALL_STATE(316)] = 5807,
+  [SMALL_STATE(317)] = 5817,
+  [SMALL_STATE(318)] = 5827,
+  [SMALL_STATE(319)] = 5837,
+  [SMALL_STATE(320)] = 5847,
+  [SMALL_STATE(321)] = 5857,
+  [SMALL_STATE(322)] = 5867,
+  [SMALL_STATE(323)] = 5877,
+  [SMALL_STATE(324)] = 5887,
+  [SMALL_STATE(325)] = 5897,
+  [SMALL_STATE(326)] = 5907,
+  [SMALL_STATE(327)] = 5917,
+  [SMALL_STATE(328)] = 5927,
+  [SMALL_STATE(329)] = 5937,
+  [SMALL_STATE(330)] = 5947,
+  [SMALL_STATE(331)] = 5954,
+  [SMALL_STATE(332)] = 5961,
+  [SMALL_STATE(333)] = 5968,
+  [SMALL_STATE(334)] = 5975,
+  [SMALL_STATE(335)] = 5982,
+  [SMALL_STATE(336)] = 5989,
+  [SMALL_STATE(337)] = 5996,
+  [SMALL_STATE(338)] = 6003,
+  [SMALL_STATE(339)] = 6010,
+  [SMALL_STATE(340)] = 6017,
+  [SMALL_STATE(341)] = 6024,
+  [SMALL_STATE(342)] = 6031,
+  [SMALL_STATE(343)] = 6038,
+  [SMALL_STATE(344)] = 6045,
+  [SMALL_STATE(345)] = 6052,
+  [SMALL_STATE(346)] = 6059,
+  [SMALL_STATE(347)] = 6066,
+  [SMALL_STATE(348)] = 6073,
+  [SMALL_STATE(349)] = 6080,
+  [SMALL_STATE(350)] = 6087,
+  [SMALL_STATE(351)] = 6094,
+  [SMALL_STATE(352)] = 6101,
+  [SMALL_STATE(353)] = 6108,
+  [SMALL_STATE(354)] = 6115,
+  [SMALL_STATE(355)] = 6122,
+  [SMALL_STATE(356)] = 6129,
+  [SMALL_STATE(357)] = 6136,
+  [SMALL_STATE(358)] = 6143,
+  [SMALL_STATE(359)] = 6150,
+  [SMALL_STATE(360)] = 6157,
+  [SMALL_STATE(361)] = 6164,
+  [SMALL_STATE(362)] = 6171,
+  [SMALL_STATE(363)] = 6178,
+  [SMALL_STATE(364)] = 6185,
+  [SMALL_STATE(365)] = 6192,
+  [SMALL_STATE(366)] = 6199,
+  [SMALL_STATE(367)] = 6206,
+  [SMALL_STATE(368)] = 6213,
+  [SMALL_STATE(369)] = 6220,
+  [SMALL_STATE(370)] = 6227,
+  [SMALL_STATE(371)] = 6234,
+  [SMALL_STATE(372)] = 6241,
+  [SMALL_STATE(373)] = 6248,
+  [SMALL_STATE(374)] = 6255,
+  [SMALL_STATE(375)] = 6262,
+  [SMALL_STATE(376)] = 6269,
+  [SMALL_STATE(377)] = 6276,
+  [SMALL_STATE(378)] = 6283,
+  [SMALL_STATE(379)] = 6290,
+  [SMALL_STATE(380)] = 6297,
+  [SMALL_STATE(381)] = 6304,
+  [SMALL_STATE(382)] = 6311,
+  [SMALL_STATE(383)] = 6318,
+  [SMALL_STATE(384)] = 6325,
+  [SMALL_STATE(385)] = 6332,
+  [SMALL_STATE(386)] = 6339,
+  [SMALL_STATE(387)] = 6346,
+  [SMALL_STATE(388)] = 6353,
+  [SMALL_STATE(389)] = 6360,
+  [SMALL_STATE(390)] = 6367,
+  [SMALL_STATE(391)] = 6374,
+  [SMALL_STATE(392)] = 6381,
+  [SMALL_STATE(393)] = 6388,
+  [SMALL_STATE(394)] = 6395,
+  [SMALL_STATE(395)] = 6402,
+  [SMALL_STATE(396)] = 6409,
+  [SMALL_STATE(397)] = 6416,
+  [SMALL_STATE(398)] = 6423,
+  [SMALL_STATE(399)] = 6430,
+  [SMALL_STATE(400)] = 6437,
+  [SMALL_STATE(401)] = 6444,
+  [SMALL_STATE(402)] = 6451,
+  [SMALL_STATE(403)] = 6458,
+  [SMALL_STATE(404)] = 6465,
+  [SMALL_STATE(405)] = 6472,
+  [SMALL_STATE(406)] = 6479,
+  [SMALL_STATE(407)] = 6486,
+  [SMALL_STATE(408)] = 6493,
+  [SMALL_STATE(409)] = 6500,
+  [SMALL_STATE(410)] = 6507,
+  [SMALL_STATE(411)] = 6514,
+  [SMALL_STATE(412)] = 6521,
+  [SMALL_STATE(413)] = 6528,
+  [SMALL_STATE(414)] = 6535,
+  [SMALL_STATE(415)] = 6542,
+  [SMALL_STATE(416)] = 6549,
+  [SMALL_STATE(417)] = 6556,
+  [SMALL_STATE(418)] = 6563,
+  [SMALL_STATE(419)] = 6570,
+  [SMALL_STATE(420)] = 6577,
+  [SMALL_STATE(421)] = 6584,
+  [SMALL_STATE(422)] = 6591,
+  [SMALL_STATE(423)] = 6598,
+  [SMALL_STATE(424)] = 6605,
+  [SMALL_STATE(425)] = 6612,
+  [SMALL_STATE(426)] = 6619,
+  [SMALL_STATE(427)] = 6626,
+  [SMALL_STATE(428)] = 6633,
+  [SMALL_STATE(429)] = 6640,
+  [SMALL_STATE(430)] = 6647,
+  [SMALL_STATE(431)] = 6654,
+  [SMALL_STATE(432)] = 6661,
+  [SMALL_STATE(433)] = 6668,
+  [SMALL_STATE(434)] = 6675,
+  [SMALL_STATE(435)] = 6682,
+  [SMALL_STATE(436)] = 6689,
+  [SMALL_STATE(437)] = 6696,
+  [SMALL_STATE(438)] = 6703,
+  [SMALL_STATE(439)] = 6710,
+  [SMALL_STATE(440)] = 6717,
+  [SMALL_STATE(441)] = 6724,
+  [SMALL_STATE(442)] = 6731,
+  [SMALL_STATE(443)] = 6738,
+  [SMALL_STATE(444)] = 6745,
+  [SMALL_STATE(445)] = 6752,
+  [SMALL_STATE(446)] = 6759,
+  [SMALL_STATE(447)] = 6766,
+  [SMALL_STATE(448)] = 6773,
+  [SMALL_STATE(449)] = 6780,
+  [SMALL_STATE(450)] = 6787,
+  [SMALL_STATE(451)] = 6794,
+  [SMALL_STATE(452)] = 6801,
+  [SMALL_STATE(453)] = 6808,
+  [SMALL_STATE(454)] = 6815,
+  [SMALL_STATE(455)] = 6822,
+  [SMALL_STATE(456)] = 6829,
+  [SMALL_STATE(457)] = 6836,
+  [SMALL_STATE(458)] = 6843,
+  [SMALL_STATE(459)] = 6850,
+  [SMALL_STATE(460)] = 6857,
+  [SMALL_STATE(461)] = 6864,
+  [SMALL_STATE(462)] = 6871,
+  [SMALL_STATE(463)] = 6878,
+  [SMALL_STATE(464)] = 6885,
+  [SMALL_STATE(465)] = 6892,
+  [SMALL_STATE(466)] = 6899,
+  [SMALL_STATE(467)] = 6906,
+  [SMALL_STATE(468)] = 6913,
+  [SMALL_STATE(469)] = 6920,
+  [SMALL_STATE(470)] = 6927,
+  [SMALL_STATE(471)] = 6934,
 };
 
 static const TSParseActionEntry ts_parse_actions[] = {
@@ -11578,574 +11968,594 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT_EXTRA(),
   [5] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 0, 0, 0),
-  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(244),
-  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
-  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(236),
-  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
-  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
-  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
-  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(395),
-  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 3, 0, 0),
-  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(230),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
+  [9] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(311),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(257),
+  [15] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [19] = {.entry = {.count = 1, .reusable = false}}, SHIFT(432),
+  [21] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 2, 0, 0),
+  [23] = {.entry = {.count = 1, .reusable = true}}, SHIFT(274),
   [25] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
-  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
-  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(368),
-  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 2, 0, 0),
-  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
-  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
-  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0),
-  [39] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(230),
-  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(5),
-  [45] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(368),
-  [48] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 4, 0, 0),
+  [27] = {.entry = {.count = 1, .reusable = true}}, SHIFT(4),
+  [29] = {.entry = {.count = 1, .reusable = false}}, SHIFT(380),
+  [31] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 3, 0, 0),
+  [33] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [35] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [37] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_settings_section, 4, 0, 0),
+  [39] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0),
+  [41] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(274),
+  [44] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(6),
+  [47] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_settings_section_repeat1, 2, 0, 0), SHIFT_REPEAT(380),
   [50] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__empty_line, 2, 0, 0),
   [52] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__empty_line, 2, 0, 0),
   [54] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_statement, 3, 0, 1),
   [56] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_setting_statement, 3, 0, 1),
-  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(259),
-  [60] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
-  [62] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
-  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(329),
-  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(339),
-  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(340),
-  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(331),
-  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(103),
-  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(342),
-  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(221),
-  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
-  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
-  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(433),
-  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(440),
-  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(340),
-  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
-  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
-  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
-  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(227),
-  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 2, 0, 0),
-  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [100] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
-  [102] = {.entry = {.count = 1, .reusable = true}}, SHIFT(229),
-  [104] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
-  [106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 3, 0, 0),
-  [108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
-  [110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
-  [112] = {.entry = {.count = 1, .reusable = true}}, SHIFT(54),
-  [114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
-  [116] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 4, 0, 0),
-  [118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0),
-  [120] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(292),
-  [123] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(262),
-  [126] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(229),
-  [129] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(21),
-  [132] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(368),
-  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 3, 0, 0),
-  [137] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 3, 0, 0),
-  [139] = {.entry = {.count = 1, .reusable = false}}, SHIFT(142),
-  [141] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
-  [143] = {.entry = {.count = 1, .reusable = false}}, SHIFT(391),
-  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 2, 0, 0),
-  [147] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 2, 0, 0),
-  [149] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
-  [151] = {.entry = {.count = 1, .reusable = false}}, SHIFT(26),
-  [153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0),
-  [155] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0),
-  [157] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(142),
-  [160] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(25),
-  [163] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(391),
-  [166] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 4, 0, 0),
-  [168] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 4, 0, 0),
-  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 2, 0, 0),
-  [172] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 2, 0, 0),
-  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(271),
-  [176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
-  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 4, 0, 0),
-  [180] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 4, 0, 0),
-  [182] = {.entry = {.count = 1, .reusable = false}}, SHIFT(30),
-  [184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0),
-  [186] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0),
-  [188] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(271),
-  [191] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(30),
-  [194] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(391),
-  [197] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_definition_body, 1, 0, 0),
-  [199] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_definition_body, 1, 0, 0),
-  [201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
-  [203] = {.entry = {.count = 1, .reusable = false}}, SHIFT(35),
-  [205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(407),
-  [207] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition_body, 1, 0, 0),
-  [209] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition_body, 1, 0, 0),
-  [211] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
-  [213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
-  [215] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2, 0, 0),
-  [217] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 3, 0, 0),
-  [219] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 3, 0, 0),
-  [221] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0),
-  [223] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0),
-  [225] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(12),
-  [228] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(35),
-  [231] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(407),
-  [234] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0),
-  [236] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0),
-  [238] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(11),
-  [241] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(36),
-  [244] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(407),
-  [247] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
-  [249] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0),
-  [251] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(244),
-  [254] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(248),
-  [257] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(236),
-  [260] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(270),
-  [263] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(280),
+  [58] = {.entry = {.count = 1, .reusable = true}}, SHIFT(290),
+  [60] = {.entry = {.count = 1, .reusable = true}}, SHIFT(354),
+  [62] = {.entry = {.count = 1, .reusable = false}}, SHIFT(88),
+  [64] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
+  [66] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
+  [68] = {.entry = {.count = 1, .reusable = true}}, SHIFT(353),
+  [70] = {.entry = {.count = 1, .reusable = true}}, SHIFT(359),
+  [72] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
+  [74] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
+  [76] = {.entry = {.count = 1, .reusable = true}}, SHIFT(242),
+  [78] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
+  [80] = {.entry = {.count = 1, .reusable = true}}, SHIFT(364),
+  [82] = {.entry = {.count = 1, .reusable = true}}, SHIFT(335),
+  [84] = {.entry = {.count = 1, .reusable = true}}, SHIFT(344),
+  [86] = {.entry = {.count = 1, .reusable = false}}, SHIFT(353),
+  [88] = {.entry = {.count = 1, .reusable = true}}, SHIFT(78),
+  [90] = {.entry = {.count = 1, .reusable = true}}, SHIFT(76),
+  [92] = {.entry = {.count = 1, .reusable = true}}, SHIFT(419),
+  [94] = {.entry = {.count = 1, .reusable = true}}, SHIFT(249),
+  [96] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 1, 0, 0),
+  [98] = {.entry = {.count = 1, .reusable = true}}, SHIFT(43),
+  [100] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0),
+  [102] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(280),
+  [105] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(281),
+  [108] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(284),
+  [111] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(17),
+  [114] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_variables_section_repeat1, 2, 0, 0), SHIFT_REPEAT(380),
+  [117] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 4, 0, 0),
+  [119] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
+  [121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(281),
+  [123] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
+  [125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 2, 0, 0),
+  [129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [131] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variables_section, 3, 0, 0),
+  [133] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 4, 0, 0),
+  [137] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 4, 0, 0),
+  [139] = {.entry = {.count = 1, .reusable = false}}, SHIFT(144),
+  [141] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [143] = {.entry = {.count = 1, .reusable = false}}, SHIFT(471),
+  [145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0),
+  [147] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0),
+  [149] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(144),
+  [152] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(23),
+  [155] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keywords_section_repeat1, 2, 0, 0), SHIFT_REPEAT(471),
+  [158] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 2, 0, 0),
+  [160] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 2, 0, 0),
+  [162] = {.entry = {.count = 1, .reusable = false}}, SHIFT(25),
+  [164] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keywords_section, 3, 0, 0),
+  [166] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keywords_section, 3, 0, 0),
+  [168] = {.entry = {.count = 1, .reusable = false}}, SHIFT(22),
+  [170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 4, 0, 0),
+  [172] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 4, 0, 0),
+  [174] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
+  [176] = {.entry = {.count = 1, .reusable = false}}, SHIFT(29),
+  [178] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0),
+  [180] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0),
+  [182] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(261),
+  [185] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(29),
+  [188] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_cases_section_repeat1, 2, 0, 0), SHIFT_REPEAT(471),
+  [191] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0),
+  [193] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(291),
+  [196] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(306),
+  [199] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(311),
+  [202] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(257),
+  [205] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat2, 2, 0, 0), SHIFT_REPEAT(262),
+  [208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition_body, 1, 0, 0),
+  [210] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition_body, 1, 0, 0),
+  [212] = {.entry = {.count = 1, .reusable = false}}, SHIFT(11),
+  [214] = {.entry = {.count = 1, .reusable = false}}, SHIFT(34),
+  [216] = {.entry = {.count = 1, .reusable = false}}, SHIFT(425),
+  [218] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_definition_body, 1, 0, 0),
+  [220] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_definition_body, 1, 0, 0),
+  [222] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [224] = {.entry = {.count = 1, .reusable = false}}, SHIFT(33),
+  [226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0),
+  [228] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0),
+  [230] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(12),
+  [233] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(33),
+  [236] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(425),
+  [239] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0),
+  [241] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0),
+  [243] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(11),
+  [246] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(34),
+  [249] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 2, 0, 0), SHIFT_REPEAT(425),
+  [252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 3, 0, 0),
+  [254] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 3, 0, 0),
+  [256] = {.entry = {.count = 1, .reusable = false}}, SHIFT(28),
+  [258] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_cases_section, 2, 0, 0),
+  [260] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_cases_section, 2, 0, 0),
+  [262] = {.entry = {.count = 1, .reusable = false}}, SHIFT(36),
+  [264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_source_file, 2, 0, 0),
   [266] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_definition, 3, 0, 0),
   [268] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_definition, 3, 0, 0),
   [270] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_definition, 4, 0, 0),
   [272] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_definition, 4, 0, 0),
-  [274] = {.entry = {.count = 1, .reusable = false}}, SHIFT(301),
-  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(302),
-  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(303),
-  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
-  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
-  [284] = {.entry = {.count = 1, .reusable = false}}, SHIFT(305),
-  [286] = {.entry = {.count = 1, .reusable = true}}, SHIFT(306),
-  [288] = {.entry = {.count = 1, .reusable = true}}, SHIFT(307),
-  [290] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
-  [292] = {.entry = {.count = 1, .reusable = true}}, SHIFT(150),
-  [294] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
-  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(132),
-  [298] = {.entry = {.count = 1, .reusable = false}}, SHIFT(420),
-  [300] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 3, 0, 0),
-  [302] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 3, 0, 0),
-  [304] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 3, 0, 0),
-  [306] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 3, 0, 0),
-  [308] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 4, 0, 0),
-  [310] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 3, 0, 0),
-  [312] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
-  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
-  [316] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(54),
-  [319] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(395),
-  [322] = {.entry = {.count = 1, .reusable = false}}, SHIFT(311),
-  [324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
-  [326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(310),
-  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
-  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
-  [332] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 2, 0, 0),
-  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(52),
+  [274] = {.entry = {.count = 1, .reusable = false}}, SHIFT(318),
+  [276] = {.entry = {.count = 1, .reusable = true}}, SHIFT(319),
+  [278] = {.entry = {.count = 1, .reusable = true}}, SHIFT(320),
+  [280] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
+  [282] = {.entry = {.count = 1, .reusable = true}}, SHIFT(124),
+  [284] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 3, 0, 0),
+  [286] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0),
+  [288] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(43),
+  [291] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_source_file_repeat1, 2, 0, 0), SHIFT_REPEAT(432),
+  [294] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 2, 0, 0),
+  [296] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
+  [298] = {.entry = {.count = 1, .reusable = false}}, SHIFT(323),
+  [300] = {.entry = {.count = 1, .reusable = true}}, SHIFT(324),
+  [302] = {.entry = {.count = 1, .reusable = true}}, SHIFT(325),
+  [304] = {.entry = {.count = 1, .reusable = true}}, SHIFT(203),
+  [306] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
+  [308] = {.entry = {.count = 1, .reusable = false}}, SHIFT(9),
+  [310] = {.entry = {.count = 1, .reusable = true}}, SHIFT(107),
+  [312] = {.entry = {.count = 1, .reusable = false}}, SHIFT(441),
+  [314] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 3, 0, 0),
+  [316] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_definition_body_repeat1, 3, 0, 0),
+  [318] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 3, 0, 0),
+  [320] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_test_case_definition_body_repeat1, 3, 0, 0),
+  [322] = {.entry = {.count = 1, .reusable = true}}, SHIFT(51),
+  [324] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comments_section, 4, 0, 0),
+  [326] = {.entry = {.count = 1, .reusable = false}}, SHIFT(295),
+  [328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(327),
+  [330] = {.entry = {.count = 1, .reusable = true}}, SHIFT(328),
+  [332] = {.entry = {.count = 1, .reusable = true}}, SHIFT(212),
+  [334] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
   [336] = {.entry = {.count = 1, .reusable = false}}, SHIFT(10),
-  [338] = {.entry = {.count = 1, .reusable = false}}, SHIFT(133),
-  [340] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 1, 0, 0),
-  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition, 3, 0, 0),
-  [344] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition, 3, 0, 0),
-  [346] = {.entry = {.count = 1, .reusable = true}}, SHIFT(308),
-  [348] = {.entry = {.count = 1, .reusable = false}}, SHIFT(111),
-  [350] = {.entry = {.count = 1, .reusable = true}}, SHIFT(352),
-  [352] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
-  [354] = {.entry = {.count = 1, .reusable = true}}, SHIFT(113),
-  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 2, 0, 0),
-  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition, 5, 0, 0),
-  [360] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition, 5, 0, 0),
-  [362] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_definition, 3, 0, 2),
-  [364] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_definition, 3, 0, 2),
-  [366] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(133),
-  [369] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(301),
-  [372] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(179),
-  [375] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(115),
-  [378] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0),
-  [380] = {.entry = {.count = 1, .reusable = false}}, SHIFT(136),
-  [382] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(136),
-  [385] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(305),
-  [388] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(193),
-  [391] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(150),
-  [394] = {.entry = {.count = 1, .reusable = false}}, SHIFT(138),
-  [396] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(138),
-  [399] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(311),
-  [402] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(198),
-  [405] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(163),
-  [408] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [410] = {.entry = {.count = 1, .reusable = false}}, SHIFT(49),
-  [412] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(211),
-  [415] = {.entry = {.count = 1, .reusable = false}}, SHIFT(188),
-  [417] = {.entry = {.count = 1, .reusable = true}}, SHIFT(301),
-  [419] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
-  [421] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_name, 2, 0, 0),
-  [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(254),
-  [425] = {.entry = {.count = 1, .reusable = false}}, SHIFT(91),
-  [427] = {.entry = {.count = 1, .reusable = true}}, SHIFT(304),
-  [429] = {.entry = {.count = 1, .reusable = true}}, SHIFT(432),
-  [431] = {.entry = {.count = 1, .reusable = true}}, SHIFT(269),
-  [433] = {.entry = {.count = 1, .reusable = false}}, SHIFT(99),
-  [435] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword, 1, 0, 0),
-  [437] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
-  [439] = {.entry = {.count = 1, .reusable = true}}, SHIFT(211),
-  [441] = {.entry = {.count = 1, .reusable = true}}, SHIFT(217),
-  [443] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_except_statement, 3, 100, 0), SHIFT(14),
-  [446] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(188),
-  [449] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(301),
-  [452] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(142),
-  [455] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0),
-  [457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
-  [459] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(49),
-  [462] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(219),
-  [465] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_name, 1, 0, 0),
-  [467] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword, 2, 0, 0),
-  [469] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
-  [471] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
-  [473] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
-  [475] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_finally_statement, 3, 100, 0), SHIFT(15),
-  [478] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
-  [480] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_except_statement, 4, 100, 0), SHIFT(15),
-  [483] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
-  [485] = {.entry = {.count = 1, .reusable = true}}, SHIFT(82),
-  [487] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_python_expression, 3, 0, 3),
-  [489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_python_expression, 3, 0, 3),
-  [491] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0),
-  [493] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
-  [496] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(108),
-  [499] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(420),
-  [502] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(211),
-  [505] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_text_chunk, 1, 0, 0),
-  [507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_text_chunk, 1, 0, 0),
-  [509] = {.entry = {.count = 1, .reusable = false}}, SHIFT(181),
-  [511] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 3, 0, 0),
-  [513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 3, 0, 0),
-  [515] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 3, 0, 0),
-  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 3, 0, 0),
-  [519] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 4, 0, 0),
-  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 4, 0, 0),
-  [523] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 4, 0, 0),
-  [525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 4, 0, 0),
-  [527] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 4, 0, 0),
-  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 4, 0, 0),
-  [531] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(49),
-  [534] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(219),
-  [537] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 5, 0, 0),
-  [539] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 5, 0, 0),
-  [541] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 5, 0, 0),
-  [543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 5, 0, 0),
-  [545] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 5, 0, 0),
-  [547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 5, 0, 0),
-  [549] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(211),
-  [552] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(49),
-  [555] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(219),
-  [558] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_python_expression, 2, 0, 0),
-  [560] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_python_expression, 2, 0, 0),
-  [562] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_block, 1, 0, 0), SHIFT(15),
-  [565] = {.entry = {.count = 1, .reusable = true}}, SHIFT(108),
-  [567] = {.entry = {.count = 1, .reusable = false}}, SHIFT(187),
-  [569] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 3, 0, 0),
-  [571] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 3, 0, 0),
-  [573] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
-  [575] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_name_chunk, 1, 0, 0),
-  [577] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_name_chunk, 1, 0, 0),
-  [579] = {.entry = {.count = 1, .reusable = false}}, SHIFT(216),
-  [581] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0),
-  [583] = {.entry = {.count = 1, .reusable = false}}, SHIFT(204),
-  [585] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(211),
-  [588] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(49),
-  [591] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(219),
-  [594] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, 0, 10), SHIFT_REPEAT(382),
-  [597] = {.entry = {.count = 1, .reusable = false}}, SHIFT(212),
-  [599] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
-  [601] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
-  [603] = {.entry = {.count = 1, .reusable = false}}, SHIFT(354),
-  [605] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
-  [607] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
-  [609] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_try_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(374),
-  [612] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
-  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
-  [616] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 1, 0, 0),
-  [618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
-  [620] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 2, 0, 0),
-  [622] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0), SHIFT(219),
-  [625] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0),
-  [627] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0), SHIFT_REPEAT(219),
-  [630] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
-  [632] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inline_python_expression_repeat1, 2, 0, 0), SHIFT_REPEAT(212),
-  [635] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_python_expression_repeat1, 2, 0, 0),
-  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
-  [639] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
-  [641] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments_without_continuation, 1, 0, 0),
-  [643] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(249),
-  [646] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0),
-  [648] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 4, 100, 0),
-  [650] = {.entry = {.count = 1, .reusable = true}}, SHIFT(410),
-  [652] = {.entry = {.count = 1, .reusable = false}}, SHIFT(189),
-  [654] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 5, 0, 0),
-  [656] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 2, 100, 0), SHIFT(49),
-  [659] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 2, 100, 0),
-  [661] = {.entry = {.count = 1, .reusable = false}}, SHIFT(240),
-  [663] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 3, 100, 0), SHIFT(49),
-  [666] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 3, 100, 0),
-  [668] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 3, 0, 0),
-  [670] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 3, 0, 0),
-  [672] = {.entry = {.count = 1, .reusable = false}}, SHIFT(320),
-  [674] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inline_python_expression_repeat1, 1, 0, 0),
-  [676] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_python_expression_repeat1, 1, 0, 0),
-  [678] = {.entry = {.count = 1, .reusable = false}}, SHIFT(175),
-  [680] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 6, 0, 0),
-  [682] = {.entry = {.count = 1, .reusable = false}}, SHIFT(260),
-  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(372),
-  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(380),
-  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
-  [690] = {.entry = {.count = 1, .reusable = false}}, SHIFT(375),
-  [692] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 4, 100, 0), SHIFT(49),
-  [695] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(49),
-  [698] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
-  [700] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0), SHIFT(211),
-  [703] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0), SHIFT_REPEAT(211),
-  [706] = {.entry = {.count = 1, .reusable = false}}, SHIFT(291),
-  [708] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
-  [710] = {.entry = {.count = 1, .reusable = false}}, SHIFT(338),
-  [712] = {.entry = {.count = 1, .reusable = false}}, SHIFT(265),
-  [714] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_setting_name, 1, 0, 0),
-  [716] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_name, 1, 0, 0),
-  [718] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_return_statement, 3, 0, 5),
-  [720] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_return_statement, 3, 0, 5),
-  [722] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
-  [724] = {.entry = {.count = 1, .reusable = false}}, SHIFT(78),
-  [726] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
-  [728] = {.entry = {.count = 1, .reusable = false}}, SHIFT(429),
-  [730] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
-  [732] = {.entry = {.count = 1, .reusable = false}}, SHIFT(371),
-  [734] = {.entry = {.count = 1, .reusable = false}}, SHIFT(347),
-  [736] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
-  [738] = {.entry = {.count = 1, .reusable = false}}, SHIFT(337),
-  [740] = {.entry = {.count = 1, .reusable = false}}, SHIFT(378),
-  [742] = {.entry = {.count = 1, .reusable = false}}, SHIFT(393),
-  [744] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
-  [746] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
-  [748] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 3, 0, 0),
-  [750] = {.entry = {.count = 1, .reusable = false}}, SHIFT(396),
-  [752] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0),
-  [754] = {.entry = {.count = 1, .reusable = false}}, SHIFT(330),
-  [756] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
-  [758] = {.entry = {.count = 1, .reusable = false}}, SHIFT(409),
-  [760] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_for_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(261),
-  [763] = {.entry = {.count = 1, .reusable = false}}, SHIFT(359),
-  [765] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
-  [767] = {.entry = {.count = 1, .reusable = false}}, SHIFT(376),
-  [769] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
-  [771] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
-  [773] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 5, 0, 0),
-  [775] = {.entry = {.count = 1, .reusable = false}}, SHIFT(431),
-  [777] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
-  [779] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_elseif_statement, 5, 100, 0),
-  [781] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_elseif_statement, 5, 100, 0),
-  [783] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_assignment, 4, 0, 0),
-  [785] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0),
-  [787] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_setting_name, 1, 0, 0),
-  [789] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting_name, 1, 0, 0),
-  [791] = {.entry = {.count = 1, .reusable = false}}, SHIFT(341),
-  [793] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
-  [795] = {.entry = {.count = 1, .reusable = false}}, SHIFT(434),
-  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(177),
-  [799] = {.entry = {.count = 1, .reusable = false}}, SHIFT(384),
-  [801] = {.entry = {.count = 1, .reusable = false}}, SHIFT(314),
-  [803] = {.entry = {.count = 1, .reusable = true}}, SHIFT(180),
-  [805] = {.entry = {.count = 1, .reusable = false}}, SHIFT(43),
-  [807] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_return_statement, 1, 0, 0),
-  [809] = {.entry = {.count = 1, .reusable = false}}, SHIFT(326),
-  [811] = {.entry = {.count = 1, .reusable = false}}, SHIFT(264),
-  [813] = {.entry = {.count = 1, .reusable = false}}, SHIFT(261),
-  [815] = {.entry = {.count = 1, .reusable = false}}, SHIFT(332),
-  [817] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
-  [819] = {.entry = {.count = 1, .reusable = false}}, SHIFT(346),
-  [821] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
-  [823] = {.entry = {.count = 1, .reusable = false}}, SHIFT(445),
-  [825] = {.entry = {.count = 1, .reusable = true}}, SHIFT(178),
-  [827] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_invocation, 2, 0, 0),
-  [829] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_invocation, 2, 0, 0),
-  [831] = {.entry = {.count = 1, .reusable = false}}, SHIFT(400),
-  [833] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_setting_name, 1, 0, 0),
-  [835] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting_name, 1, 0, 0),
-  [837] = {.entry = {.count = 1, .reusable = false}}, SHIFT(316),
-  [839] = {.entry = {.count = 1, .reusable = true}}, SHIFT(23),
-  [841] = {.entry = {.count = 1, .reusable = false}}, SHIFT(279),
-  [843] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
-  [845] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_statement, 1, 0, 0),
-  [847] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_statement, 1, 0, 0),
-  [849] = {.entry = {.count = 1, .reusable = false}}, SHIFT(398),
-  [851] = {.entry = {.count = 1, .reusable = true}}, SHIFT(106),
-  [853] = {.entry = {.count = 1, .reusable = false}}, SHIFT(377),
-  [855] = {.entry = {.count = 1, .reusable = false}}, SHIFT(379),
-  [857] = {.entry = {.count = 1, .reusable = true}}, SHIFT(139),
-  [859] = {.entry = {.count = 1, .reusable = false}}, SHIFT(381),
-  [861] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
-  [863] = {.entry = {.count = 1, .reusable = false}}, SHIFT(383),
-  [865] = {.entry = {.count = 1, .reusable = true}}, SHIFT(119),
-  [867] = {.entry = {.count = 1, .reusable = false}}, SHIFT(333),
-  [869] = {.entry = {.count = 1, .reusable = true}}, SHIFT(27),
-  [871] = {.entry = {.count = 1, .reusable = false}}, SHIFT(386),
-  [873] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
-  [875] = {.entry = {.count = 1, .reusable = false}}, SHIFT(387),
-  [877] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
-  [879] = {.entry = {.count = 1, .reusable = false}}, SHIFT(388),
-  [881] = {.entry = {.count = 1, .reusable = true}}, SHIFT(123),
-  [883] = {.entry = {.count = 1, .reusable = false}}, SHIFT(397),
-  [885] = {.entry = {.count = 1, .reusable = true}}, SHIFT(151),
-  [887] = {.entry = {.count = 1, .reusable = false}}, SHIFT(399),
-  [889] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
-  [891] = {.entry = {.count = 1, .reusable = false}}, SHIFT(401),
-  [893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
-  [895] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
-  [897] = {.entry = {.count = 1, .reusable = false}}, SHIFT(404),
-  [899] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
-  [901] = {.entry = {.count = 1, .reusable = false}}, SHIFT(405),
-  [903] = {.entry = {.count = 1, .reusable = true}}, SHIFT(156),
-  [905] = {.entry = {.count = 1, .reusable = false}}, SHIFT(406),
-  [907] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
-  [909] = {.entry = {.count = 1, .reusable = false}}, SHIFT(318),
-  [911] = {.entry = {.count = 1, .reusable = false}}, SHIFT(258),
-  [913] = {.entry = {.count = 1, .reusable = false}}, SHIFT(412),
-  [915] = {.entry = {.count = 1, .reusable = true}}, SHIFT(355),
-  [917] = {.entry = {.count = 1, .reusable = false}}, SHIFT(414),
-  [919] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
-  [921] = {.entry = {.count = 1, .reusable = false}}, SHIFT(416),
-  [923] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
-  [925] = {.entry = {.count = 1, .reusable = false}}, SHIFT(417),
-  [927] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
-  [929] = {.entry = {.count = 1, .reusable = false}}, SHIFT(418),
-  [931] = {.entry = {.count = 1, .reusable = true}}, SHIFT(166),
-  [933] = {.entry = {.count = 1, .reusable = false}}, SHIFT(419),
-  [935] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
-  [937] = {.entry = {.count = 1, .reusable = false}}, SHIFT(423),
-  [939] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
-  [941] = {.entry = {.count = 1, .reusable = false}}, SHIFT(424),
-  [943] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
-  [945] = {.entry = {.count = 1, .reusable = false}}, SHIFT(428),
-  [947] = {.entry = {.count = 1, .reusable = false}}, SHIFT(276),
-  [949] = {.entry = {.count = 1, .reusable = false}}, SHIFT(313),
-  [951] = {.entry = {.count = 1, .reusable = false}}, SHIFT(277),
-  [953] = {.entry = {.count = 1, .reusable = false}}, SHIFT(430),
-  [955] = {.entry = {.count = 1, .reusable = false}}, SHIFT(278),
-  [957] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
-  [959] = {.entry = {.count = 1, .reusable = false}}, SHIFT(436),
-  [961] = {.entry = {.count = 1, .reusable = false}}, SHIFT(284),
-  [963] = {.entry = {.count = 1, .reusable = false}}, SHIFT(437),
-  [965] = {.entry = {.count = 1, .reusable = false}}, SHIFT(285),
-  [967] = {.entry = {.count = 1, .reusable = false}}, SHIFT(438),
-  [969] = {.entry = {.count = 1, .reusable = false}}, SHIFT(286),
-  [971] = {.entry = {.count = 1, .reusable = false}}, SHIFT(442),
-  [973] = {.entry = {.count = 1, .reusable = false}}, SHIFT(293),
-  [975] = {.entry = {.count = 1, .reusable = false}}, SHIFT(443),
-  [977] = {.entry = {.count = 1, .reusable = false}}, SHIFT(294),
-  [979] = {.entry = {.count = 1, .reusable = false}}, SHIFT(444),
-  [981] = {.entry = {.count = 1, .reusable = false}}, SHIFT(295),
-  [983] = {.entry = {.count = 1, .reusable = false}}, SHIFT(446),
-  [985] = {.entry = {.count = 1, .reusable = false}}, SHIFT(299),
-  [987] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_assignment, 5, 0, 0),
-  [989] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_assignment, 5, 0, 0),
-  [991] = {.entry = {.count = 1, .reusable = false}}, SHIFT(282),
-  [993] = {.entry = {.count = 1, .reusable = true}}, SHIFT(98),
-  [995] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
-  [997] = {.entry = {.count = 1, .reusable = true}}, SHIFT(75),
-  [999] = {.entry = {.count = 1, .reusable = false}}, SHIFT(251),
-  [1001] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
-  [1003] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, 200, 0),
-  [1005] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_enumerate, 2, 0, 0),
-  [1007] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_zip, 2, 0, 0),
-  [1009] = {.entry = {.count = 1, .reusable = false}}, SHIFT(317),
-  [1011] = {.entry = {.count = 1, .reusable = false}}, SHIFT(256),
-  [1013] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_statement, 4, 100, 11),
-  [1015] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_statement, 4, 100, 0),
-  [1017] = {.entry = {.count = 1, .reusable = false}}, SHIFT(44),
-  [1019] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
-  [1021] = {.entry = {.count = 1, .reusable = true}}, SHIFT(45),
-  [1023] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
-  [1025] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 1, 0, 0),
-  [1027] = {.entry = {.count = 1, .reusable = true}}, SHIFT(46),
-  [1029] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_finally_statement, 4, 100, 0),
-  [1031] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
-  [1033] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 4, 200, 0),
-  [1035] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
-  [1037] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
-  [1039] = {.entry = {.count = 1, .reusable = true}}, SHIFT(93),
-  [1041] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 6, 0, 12),
-  [1043] = {.entry = {.count = 1, .reusable = true}}, SHIFT(210),
-  [1045] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
-  [1047] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
-  [1049] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 6, 0, 6),
-  [1051] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
-  [1053] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
-  [1055] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
-  [1057] = {.entry = {.count = 1, .reusable = false}}, SHIFT(51),
-  [1059] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
-  [1061] = {.entry = {.count = 1, .reusable = false}}, SHIFT(85),
-  [1063] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 5, 0, 6),
-  [1065] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
-  [1067] = {.entry = {.count = 1, .reusable = true}}, SHIFT(104),
-  [1069] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
-  [1071] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
-  [1073] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 4, 0, 4),
-  [1075] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 6, 0, 6),
-  [1077] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 7, 0, 0),
-  [1079] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_for_statement_repeat1, 2, 0, 0),
-  [1081] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 5, 0, 4),
-  [1083] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
-  [1085] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 1, 0, 7),
-  [1087] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 13),
-  [1089] = {.entry = {.count = 1, .reusable = true}}, SHIFT(408),
-  [1091] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 14),
-  [1093] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 4, 0, 4),
-  [1095] = {.entry = {.count = 1, .reusable = true}}, SHIFT(213),
-  [1097] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
-  [1099] = {.entry = {.count = 1, .reusable = true}}, SHIFT(370),
-  [1101] = {.entry = {.count = 1, .reusable = true}}, SHIFT(413),
-  [1103] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 15),
-  [1105] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 5, 0, 4),
-  [1107] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
-  [1109] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
-  [1111] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
-  [1113] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, 200, 0),
-  [1115] = {.entry = {.count = 1, .reusable = true}}, SHIFT(84),
-  [1117] = {.entry = {.count = 1, .reusable = true}}, SHIFT(65),
-  [1119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 7, 200, 0),
-  [1121] = {.entry = {.count = 1, .reusable = true}}, SHIFT(415),
-  [1123] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_statement, 5, 100, 0),
-  [1125] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
-  [1127] = {.entry = {.count = 1, .reusable = true}}, SHIFT(422),
-  [1129] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
-  [1131] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
-  [1133] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 8, 0, 0),
-  [1135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, 0, 8),
-  [1137] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
-  [1139] = {.entry = {.count = 1, .reusable = true}}, SHIFT(161),
-  [1141] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
-  [1143] = {.entry = {.count = 1, .reusable = true}}, SHIFT(42),
-  [1145] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 16),
-  [1147] = {.entry = {.count = 1, .reusable = true}}, SHIFT(427),
-  [1149] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 17),
-  [1151] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
-  [1153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 18),
-  [1155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 8, 200, 0),
-  [1157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(361),
-  [1159] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
-  [1161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
-  [1163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(200),
-  [1165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in, 2, 0, 0),
-  [1167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, 0, 19),
-  [1169] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
-  [1171] = {.entry = {.count = 1, .reusable = false}}, SHIFT(86),
-  [1173] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_else_statement, 3, 100, 0),
-  [1175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 9, 0, 20),
-  [1177] = {.entry = {.count = 1, .reusable = false}}, SHIFT(281),
-  [1179] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
-  [1181] = {.entry = {.count = 1, .reusable = false}}, SHIFT(283),
-  [1183] = {.entry = {.count = 1, .reusable = true}}, SHIFT(190),
-  [1185] = {.entry = {.count = 1, .reusable = false}}, SHIFT(390),
-  [1187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, 0, 9),
-  [1189] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
-  [1191] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elseif_statement, 6, 100, 21),
-  [1193] = {.entry = {.count = 1, .reusable = false}}, SHIFT(288),
-  [1195] = {.entry = {.count = 1, .reusable = false}}, SHIFT(289),
-  [1197] = {.entry = {.count = 1, .reusable = false}}, SHIFT(290),
-  [1199] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 7, 0, 0),
-  [1201] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
-  [1203] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 5, 0, 6),
-  [1205] = {.entry = {.count = 1, .reusable = false}}, SHIFT(296),
-  [1207] = {.entry = {.count = 1, .reusable = false}}, SHIFT(297),
-  [1209] = {.entry = {.count = 1, .reusable = false}}, SHIFT(298),
-  [1211] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
-  [1213] = {.entry = {.count = 1, .reusable = false}}, SHIFT(300),
-  [1215] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [338] = {.entry = {.count = 1, .reusable = false}}, SHIFT(119),
+  [340] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 2, 0, 0),
+  [342] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition, 5, 0, 0),
+  [344] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition, 5, 0, 0),
+  [346] = {.entry = {.count = 1, .reusable = true}}, SHIFT(326),
+  [348] = {.entry = {.count = 1, .reusable = false}}, SHIFT(117),
+  [350] = {.entry = {.count = 1, .reusable = true}}, SHIFT(363),
+  [352] = {.entry = {.count = 1, .reusable = true}}, SHIFT(118),
+  [354] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
+  [356] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument, 1, 0, 0),
+  [358] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_definition, 3, 0, 2),
+  [360] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_definition, 3, 0, 2),
+  [362] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(119),
+  [365] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(318),
+  [368] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(200),
+  [371] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(124),
+  [374] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0),
+  [376] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_definition, 3, 0, 0),
+  [378] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_definition, 3, 0, 0),
+  [380] = {.entry = {.count = 1, .reusable = false}}, SHIFT(139),
+  [382] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(139),
+  [385] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(323),
+  [388] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(203),
+  [391] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(151),
+  [394] = {.entry = {.count = 1, .reusable = false}}, SHIFT(104),
+  [396] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(104),
+  [399] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(295),
+  [402] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(212),
+  [405] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0), SHIFT_REPEAT(166),
+  [408] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(198),
+  [411] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(318),
+  [414] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0), SHIFT_REPEAT(144),
+  [417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0),
+  [419] = {.entry = {.count = 1, .reusable = true}}, SHIFT(270),
+  [421] = {.entry = {.count = 1, .reusable = false}}, SHIFT(97),
+  [423] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
+  [425] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_except_statement, 3, 100, 0), SHIFT(14),
+  [428] = {.entry = {.count = 1, .reusable = true}}, SHIFT(286),
+  [430] = {.entry = {.count = 1, .reusable = false}}, SHIFT(98),
+  [432] = {.entry = {.count = 1, .reusable = true}}, SHIFT(112),
+  [434] = {.entry = {.count = 1, .reusable = false}}, SHIFT(52),
+  [436] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(239),
+  [439] = {.entry = {.count = 1, .reusable = false}}, SHIFT(198),
+  [441] = {.entry = {.count = 1, .reusable = true}}, SHIFT(318),
+  [443] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
+  [445] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword, 2, 0, 0),
+  [447] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
+  [449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
+  [451] = {.entry = {.count = 1, .reusable = true}}, SHIFT(109),
+  [453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(239),
+  [455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
+  [457] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(52),
+  [460] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 3, 0, 0), SHIFT(228),
+  [463] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_name, 1, 0, 0),
+  [465] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_name, 2, 0, 0),
+  [467] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword, 1, 0, 0),
+  [469] = {.entry = {.count = 1, .reusable = false}}, SHIFT(15),
+  [471] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_except_statement, 4, 100, 0), SHIFT(15),
+  [474] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_finally_statement, 3, 100, 0), SHIFT(15),
+  [477] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_section, 1, 0, 0),
+  [479] = {.entry = {.count = 1, .reusable = true}}, SHIFT(31),
+  [481] = {.entry = {.count = 1, .reusable = true}}, SHIFT(32),
+  [483] = {.entry = {.count = 1, .reusable = false}}, SHIFT(13),
+  [485] = {.entry = {.count = 1, .reusable = false}}, SHIFT(182),
+  [487] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_block, 1, 0, 0), SHIFT(15),
+  [490] = {.entry = {.count = 1, .reusable = true}}, SHIFT(116),
+  [492] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(239),
+  [495] = {.entry = {.count = 1, .reusable = false}}, SHIFT(183),
+  [497] = {.entry = {.count = 1, .reusable = true}}, SHIFT(77),
+  [499] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_python_expression, 2, 0, 0),
+  [501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_python_expression, 2, 0, 0),
+  [503] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(15),
+  [506] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(116),
+  [509] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 2, 0, 0), SHIFT_REPEAT(441),
+  [512] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(239),
+  [515] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_text_chunk, 1, 0, 0),
+  [517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_text_chunk, 1, 0, 0),
+  [519] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_python_expression, 3, 0, 3),
+  [521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_python_expression, 3, 0, 3),
+  [523] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 3, 0, 0),
+  [525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 3, 0, 0),
+  [527] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 3, 0, 0),
+  [529] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 3, 0, 0),
+  [531] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 3, 0, 0),
+  [533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 3, 0, 0),
+  [535] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 4, 0, 0),
+  [537] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 4, 0, 0),
+  [539] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 4, 0, 0),
+  [541] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 4, 0, 0),
+  [543] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 4, 0, 0),
+  [545] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 4, 0, 0),
+  [547] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(52),
+  [550] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_keyword_invocation, 1, 0, 0), SHIFT(228),
+  [553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_repeat1, 2, 0, 0),
+  [555] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 5, 0, 0),
+  [557] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 5, 0, 0),
+  [559] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_variable, 5, 0, 0),
+  [561] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_variable, 5, 0, 0),
+  [563] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_variable, 5, 0, 0),
+  [565] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_variable, 5, 0, 0),
+  [567] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_scalar_variable, 6, 0, 0),
+  [569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_scalar_variable, 6, 0, 0),
+  [571] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(52),
+  [574] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0), SHIFT(228),
+  [577] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_name_chunk, 1, 0, 0),
+  [579] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_name_chunk, 1, 0, 0),
+  [581] = {.entry = {.count = 1, .reusable = false}}, SHIFT(229),
+  [583] = {.entry = {.count = 1, .reusable = false}}, SHIFT(236),
+  [585] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(239),
+  [588] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(52),
+  [591] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 1, 0, 0), SHIFT(228),
+  [594] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_keyword_name_repeat1, 2, 0, 0),
+  [596] = {.entry = {.count = 1, .reusable = false}}, SHIFT(254),
+  [598] = {.entry = {.count = 1, .reusable = false}}, SHIFT(420),
+  [600] = {.entry = {.count = 1, .reusable = true}}, SHIFT(248),
+  [602] = {.entry = {.count = 1, .reusable = true}}, SHIFT(179),
+  [604] = {.entry = {.count = 1, .reusable = false}}, SHIFT(448),
+  [606] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
+  [608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(389),
+  [610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(442),
+  [612] = {.entry = {.count = 1, .reusable = false}}, SHIFT(410),
+  [614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(152),
+  [616] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_scalar_variable_repeat1, 2, 0, 0),
+  [618] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_scalar_variable_repeat1, 2, 0, 0), SHIFT_REPEAT(248),
+  [621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_variable_repeat1, 2, 0, 0),
+  [623] = {.entry = {.count = 1, .reusable = true}}, SHIFT(456),
+  [625] = {.entry = {.count = 1, .reusable = false}}, SHIFT(458),
+  [627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(99),
+  [629] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, 0, 10), SHIFT_REPEAT(357),
+  [632] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_try_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(413),
+  [635] = {.entry = {.count = 1, .reusable = false}}, SHIFT(459),
+  [637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
+  [639] = {.entry = {.count = 1, .reusable = false}}, SHIFT(227),
+  [641] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
+  [643] = {.entry = {.count = 1, .reusable = false}}, SHIFT(349),
+  [645] = {.entry = {.count = 1, .reusable = true}}, SHIFT(149),
+  [647] = {.entry = {.count = 1, .reusable = true}}, SHIFT(115),
+  [649] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 1, 0, 0),
+  [651] = {.entry = {.count = 1, .reusable = false}}, SHIFT(391),
+  [653] = {.entry = {.count = 1, .reusable = true}}, SHIFT(126),
+  [655] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
+  [657] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_arguments, 2, 0, 0),
+  [659] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0), SHIFT(228),
+  [662] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0),
+  [664] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0), SHIFT_REPEAT(228),
+  [667] = {.entry = {.count = 1, .reusable = false}}, SHIFT(399),
+  [669] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
+  [671] = {.entry = {.count = 1, .reusable = true}}, SHIFT(142),
+  [673] = {.entry = {.count = 1, .reusable = false}}, SHIFT(403),
+  [675] = {.entry = {.count = 1, .reusable = true}}, SHIFT(134),
+  [677] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inline_python_expression_repeat1, 2, 0, 0), SHIFT_REPEAT(227),
+  [680] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_python_expression_repeat1, 2, 0, 0),
+  [682] = {.entry = {.count = 1, .reusable = false}}, SHIFT(412),
+  [684] = {.entry = {.count = 1, .reusable = true}}, SHIFT(153),
+  [686] = {.entry = {.count = 1, .reusable = true}}, SHIFT(141),
+  [688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(160),
+  [690] = {.entry = {.count = 1, .reusable = false}}, SHIFT(424),
+  [692] = {.entry = {.count = 1, .reusable = true}}, SHIFT(162),
+  [694] = {.entry = {.count = 1, .reusable = false}}, SHIFT(430),
+  [696] = {.entry = {.count = 1, .reusable = true}}, SHIFT(365),
+  [698] = {.entry = {.count = 1, .reusable = false}}, SHIFT(436),
+  [700] = {.entry = {.count = 1, .reusable = true}}, SHIFT(368),
+  [702] = {.entry = {.count = 1, .reusable = false}}, SHIFT(440),
+  [704] = {.entry = {.count = 1, .reusable = true}}, SHIFT(371),
+  [706] = {.entry = {.count = 1, .reusable = false}}, SHIFT(444),
+  [708] = {.entry = {.count = 1, .reusable = true}}, SHIFT(173),
+  [710] = {.entry = {.count = 1, .reusable = false}}, SHIFT(446),
+  [712] = {.entry = {.count = 1, .reusable = true}}, SHIFT(174),
+  [714] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 3, 100, 0), SHIFT(52),
+  [717] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 3, 100, 0),
+  [719] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 4, 100, 0), SHIFT(52),
+  [722] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 4, 100, 0),
+  [724] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inline_python_expression_repeat1, 1, 0, 0),
+  [726] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_python_expression_repeat1, 1, 0, 0),
+  [728] = {.entry = {.count = 1, .reusable = true}}, SHIFT(253),
+  [730] = {.entry = {.count = 1, .reusable = false}}, SHIFT(387),
+  [732] = {.entry = {.count = 1, .reusable = true}}, SHIFT(350),
+  [734] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_scalar_variable_repeat1, 3, 0, 0),
+  [736] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_scalar_variable_repeat1, 3, 0, 0),
+  [738] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continuation, 2, 100, 0),
+  [740] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_block_repeat1, 3, 0, 0),
+  [742] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_block_repeat1, 3, 0, 0),
+  [744] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(271),
+  [747] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0),
+  [749] = {.entry = {.count = 1, .reusable = true}}, SHIFT(393),
+  [751] = {.entry = {.count = 1, .reusable = false}}, SHIFT(188),
+  [753] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 5, 0, 0),
+  [755] = {.entry = {.count = 1, .reusable = false}}, SHIFT(260),
+  [757] = {.entry = {.count = 1, .reusable = false}}, SHIFT(465),
+  [759] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0), SHIFT_REPEAT(52),
+  [762] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
+  [764] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_arguments, 2, 0, 0), SHIFT(239),
+  [767] = {.entry = {.count = 1, .reusable = false}}, SHIFT(255),
+  [769] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_arguments_without_continuation, 1, 0, 0),
+  [771] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_arguments_repeat2, 2, 0, 0), SHIFT_REPEAT(239),
+  [774] = {.entry = {.count = 1, .reusable = false}}, SHIFT(469),
+  [776] = {.entry = {.count = 1, .reusable = false}}, SHIFT(288),
+  [778] = {.entry = {.count = 1, .reusable = false}}, SHIFT(192),
+  [780] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 6, 0, 0),
+  [782] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_continuation, 2, 100, 0), SHIFT(52),
+  [785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
+  [787] = {.entry = {.count = 1, .reusable = false}}, SHIFT(339),
+  [789] = {.entry = {.count = 1, .reusable = false}}, SHIFT(450),
+  [791] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [793] = {.entry = {.count = 1, .reusable = false}}, SHIFT(348),
+  [795] = {.entry = {.count = 1, .reusable = false}}, SHIFT(362),
+  [797] = {.entry = {.count = 1, .reusable = true}}, SHIFT(360),
+  [799] = {.entry = {.count = 1, .reusable = false}}, SHIFT(342),
+  [801] = {.entry = {.count = 1, .reusable = true}}, SHIFT(37),
+  [803] = {.entry = {.count = 1, .reusable = false}}, SHIFT(41),
+  [805] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 3, 0, 0),
+  [807] = {.entry = {.count = 1, .reusable = false}}, SHIFT(376),
+  [809] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_inline_if_statement_repeat1, 2, 0, 0),
+  [811] = {.entry = {.count = 1, .reusable = false}}, SHIFT(390),
+  [813] = {.entry = {.count = 1, .reusable = false}}, SHIFT(62),
+  [815] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_invocation, 2, 0, 0),
+  [817] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_invocation, 2, 0, 0),
+  [819] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_test_case_setting_name, 1, 0, 0),
+  [821] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting_name, 1, 0, 0),
+  [823] = {.entry = {.count = 1, .reusable = false}}, SHIFT(56),
+  [825] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 5, 0, 0),
+  [827] = {.entry = {.count = 1, .reusable = false}}, SHIFT(337),
+  [829] = {.entry = {.count = 1, .reusable = true}}, SHIFT(110),
+  [831] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_setting_name, 1, 0, 0),
+  [833] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_setting_name, 1, 0, 0),
+  [835] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_elseif_statement, 5, 100, 0),
+  [837] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_elseif_statement, 5, 100, 0),
+  [839] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_arguments_repeat1, 2, 0, 0),
+  [841] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_return_statement, 3, 0, 5),
+  [843] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_return_statement, 3, 0, 5),
+  [845] = {.entry = {.count = 1, .reusable = false}}, SHIFT(84),
+  [847] = {.entry = {.count = 1, .reusable = true}}, SHIFT(59),
+  [849] = {.entry = {.count = 1, .reusable = false}}, SHIFT(351),
+  [851] = {.entry = {.count = 1, .reusable = false}}, SHIFT(345),
+  [853] = {.entry = {.count = 1, .reusable = false}}, SHIFT(199),
+  [855] = {.entry = {.count = 1, .reusable = false}}, SHIFT(361),
+  [857] = {.entry = {.count = 1, .reusable = false}}, SHIFT(294),
+  [859] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_for_statement_repeat1, 2, 0, 0), SHIFT_REPEAT(266),
+  [862] = {.entry = {.count = 1, .reusable = false}}, SHIFT(369),
+  [864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(120),
+  [866] = {.entry = {.count = 1, .reusable = false}}, SHIFT(383),
+  [868] = {.entry = {.count = 1, .reusable = false}}, SHIFT(305),
+  [870] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_assignment, 4, 0, 0),
+  [872] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_assignment, 4, 0, 0),
+  [874] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_keyword_setting_name, 1, 0, 0),
+  [876] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting_name, 1, 0, 0),
+  [878] = {.entry = {.count = 1, .reusable = false}}, SHIFT(388),
+  [880] = {.entry = {.count = 1, .reusable = false}}, SHIFT(447),
+  [882] = {.entry = {.count = 1, .reusable = true}}, SHIFT(102),
+  [884] = {.entry = {.count = 1, .reusable = false}}, SHIFT(45),
+  [886] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_return_statement, 1, 0, 0),
+  [888] = {.entry = {.count = 1, .reusable = false}}, SHIFT(377),
+  [890] = {.entry = {.count = 1, .reusable = true}}, SHIFT(44),
+  [892] = {.entry = {.count = 1, .reusable = false}}, SHIFT(418),
+  [894] = {.entry = {.count = 1, .reusable = false}}, SHIFT(266),
+  [896] = {.entry = {.count = 1, .reusable = false}}, SHIFT(378),
+  [898] = {.entry = {.count = 1, .reusable = true}}, SHIFT(224),
+  [900] = {.entry = {.count = 1, .reusable = false}}, SHIFT(470),
+  [902] = {.entry = {.count = 1, .reusable = false}}, SHIFT(221),
+  [904] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_variable_assignment, 5, 0, 0),
+  [906] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_variable_assignment, 5, 0, 0),
+  [908] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_inline_statement, 1, 0, 0),
+  [910] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_statement, 1, 0, 0),
+  [912] = {.entry = {.count = 1, .reusable = false}}, SHIFT(406),
+  [914] = {.entry = {.count = 1, .reusable = false}}, SHIFT(394),
+  [916] = {.entry = {.count = 1, .reusable = true}}, SHIFT(127),
+  [918] = {.entry = {.count = 1, .reusable = false}}, SHIFT(396),
+  [920] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
+  [922] = {.entry = {.count = 1, .reusable = false}}, SHIFT(338),
+  [924] = {.entry = {.count = 1, .reusable = true}}, SHIFT(191),
+  [926] = {.entry = {.count = 1, .reusable = false}}, SHIFT(464),
+  [928] = {.entry = {.count = 1, .reusable = false}}, SHIFT(401),
+  [930] = {.entry = {.count = 1, .reusable = true}}, SHIFT(130),
+  [932] = {.entry = {.count = 1, .reusable = false}}, SHIFT(402),
+  [934] = {.entry = {.count = 1, .reusable = true}}, SHIFT(131),
+  [936] = {.entry = {.count = 1, .reusable = false}}, SHIFT(392),
+  [938] = {.entry = {.count = 1, .reusable = true}}, SHIFT(184),
+  [940] = {.entry = {.count = 1, .reusable = false}}, SHIFT(428),
+  [942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [944] = {.entry = {.count = 1, .reusable = false}}, SHIFT(415),
+  [946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(154),
+  [948] = {.entry = {.count = 1, .reusable = false}}, SHIFT(417),
+  [950] = {.entry = {.count = 1, .reusable = true}}, SHIFT(155),
+  [952] = {.entry = {.count = 1, .reusable = false}}, SHIFT(422),
+  [954] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
+  [956] = {.entry = {.count = 1, .reusable = false}}, SHIFT(423),
+  [958] = {.entry = {.count = 1, .reusable = true}}, SHIFT(159),
+  [960] = {.entry = {.count = 1, .reusable = false}}, SHIFT(347),
+  [962] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [964] = {.entry = {.count = 1, .reusable = false}}, SHIFT(433),
+  [966] = {.entry = {.count = 1, .reusable = true}}, SHIFT(167),
+  [968] = {.entry = {.count = 1, .reusable = false}}, SHIFT(435),
+  [970] = {.entry = {.count = 1, .reusable = true}}, SHIFT(168),
+  [972] = {.entry = {.count = 1, .reusable = false}}, SHIFT(438),
+  [974] = {.entry = {.count = 1, .reusable = true}}, SHIFT(169),
+  [976] = {.entry = {.count = 1, .reusable = false}}, SHIFT(439),
+  [978] = {.entry = {.count = 1, .reusable = true}}, SHIFT(170),
+  [980] = {.entry = {.count = 1, .reusable = false}}, SHIFT(322),
+  [982] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
+  [984] = {.entry = {.count = 1, .reusable = false}}, SHIFT(449),
+  [986] = {.entry = {.count = 1, .reusable = true}}, SHIFT(140),
+  [988] = {.entry = {.count = 1, .reusable = false}}, SHIFT(452),
+  [990] = {.entry = {.count = 1, .reusable = false}}, SHIFT(202),
+  [992] = {.entry = {.count = 1, .reusable = false}}, SHIFT(453),
+  [994] = {.entry = {.count = 1, .reusable = false}}, SHIFT(299),
+  [996] = {.entry = {.count = 1, .reusable = false}}, SHIFT(454),
+  [998] = {.entry = {.count = 1, .reusable = false}}, SHIFT(300),
+  [1000] = {.entry = {.count = 1, .reusable = false}}, SHIFT(58),
+  [1002] = {.entry = {.count = 1, .reusable = false}}, SHIFT(460),
+  [1004] = {.entry = {.count = 1, .reusable = false}}, SHIFT(211),
+  [1006] = {.entry = {.count = 1, .reusable = false}}, SHIFT(461),
+  [1008] = {.entry = {.count = 1, .reusable = false}}, SHIFT(307),
+  [1010] = {.entry = {.count = 1, .reusable = false}}, SHIFT(462),
+  [1012] = {.entry = {.count = 1, .reusable = false}}, SHIFT(308),
+  [1014] = {.entry = {.count = 1, .reusable = false}}, SHIFT(466),
+  [1016] = {.entry = {.count = 1, .reusable = false}}, SHIFT(217),
+  [1018] = {.entry = {.count = 1, .reusable = false}}, SHIFT(467),
+  [1020] = {.entry = {.count = 1, .reusable = false}}, SHIFT(312),
+  [1022] = {.entry = {.count = 1, .reusable = false}}, SHIFT(468),
+  [1024] = {.entry = {.count = 1, .reusable = false}}, SHIFT(313),
+  [1026] = {.entry = {.count = 1, .reusable = false}}, SHIFT(332),
+  [1028] = {.entry = {.count = 1, .reusable = true}}, SHIFT(187),
+  [1030] = {.entry = {.count = 1, .reusable = false}}, SHIFT(405),
+  [1032] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 7, 0, 0),
+  [1034] = {.entry = {.count = 1, .reusable = true}}, SHIFT(193),
+  [1036] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_for_statement_repeat1, 2, 0, 0),
+  [1038] = {.entry = {.count = 1, .reusable = true}}, SHIFT(100),
+  [1040] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, 0, 9),
+  [1042] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 13),
+  [1044] = {.entry = {.count = 1, .reusable = true}}, SHIFT(121),
+  [1046] = {.entry = {.count = 1, .reusable = true}}, SHIFT(194),
+  [1048] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
+  [1050] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 5, 0, 6),
+  [1052] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 5, 0, 4),
+  [1054] = {.entry = {.count = 1, .reusable = true}}, SHIFT(35),
+  [1056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 14),
+  [1058] = {.entry = {.count = 1, .reusable = false}}, SHIFT(54),
+  [1060] = {.entry = {.count = 1, .reusable = false}}, SHIFT(196),
+  [1062] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_statement, 4, 100, 11),
+  [1064] = {.entry = {.count = 1, .reusable = true}}, SHIFT(21),
+  [1066] = {.entry = {.count = 1, .reusable = true}}, SHIFT(397),
+  [1068] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, 0, 15),
+  [1070] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 4, 200, 0),
+  [1072] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
+  [1074] = {.entry = {.count = 1, .reusable = false}}, SHIFT(385),
+  [1076] = {.entry = {.count = 1, .reusable = true}}, SHIFT(92),
+  [1078] = {.entry = {.count = 1, .reusable = true}}, SHIFT(234),
+  [1080] = {.entry = {.count = 1, .reusable = false}}, SHIFT(46),
+  [1082] = {.entry = {.count = 1, .reusable = true}}, SHIFT(47),
+  [1084] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 7, 200, 0),
+  [1086] = {.entry = {.count = 1, .reusable = false}}, SHIFT(329),
+  [1088] = {.entry = {.count = 1, .reusable = true}}, SHIFT(400),
+  [1090] = {.entry = {.count = 1, .reusable = false}}, SHIFT(53),
+  [1092] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 1, 0, 0),
+  [1094] = {.entry = {.count = 1, .reusable = true}}, SHIFT(48),
+  [1096] = {.entry = {.count = 1, .reusable = true}}, SHIFT(89),
+  [1098] = {.entry = {.count = 1, .reusable = true}}, SHIFT(122),
+  [1100] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_statement, 5, 100, 0),
+  [1102] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_statement, 4, 100, 0),
+  [1104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 4, 0, 4),
+  [1106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 6, 0, 6),
+  [1108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
+  [1110] = {.entry = {.count = 1, .reusable = true}}, SHIFT(50),
+  [1112] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 1, 0, 7),
+  [1114] = {.entry = {.count = 1, .reusable = true}}, SHIFT(7),
+  [1116] = {.entry = {.count = 1, .reusable = true}}, SHIFT(64),
+  [1118] = {.entry = {.count = 1, .reusable = true}}, SHIFT(49),
+  [1120] = {.entry = {.count = 1, .reusable = false}}, SHIFT(301),
+  [1122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_if_statement, 8, 0, 0),
+  [1124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(79),
+  [1126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 16),
+  [1128] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
+  [1130] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, 200, 0),
+  [1132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(426),
+  [1134] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 17),
+  [1136] = {.entry = {.count = 1, .reusable = true}}, SHIFT(95),
+  [1138] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 8, 0, 18),
+  [1140] = {.entry = {.count = 1, .reusable = true}}, SHIFT(40),
+  [1142] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 8, 200, 0),
+  [1144] = {.entry = {.count = 1, .reusable = true}}, SHIFT(135),
+  [1146] = {.entry = {.count = 1, .reusable = true}}, SHIFT(136),
+  [1148] = {.entry = {.count = 1, .reusable = true}}, SHIFT(137),
+  [1150] = {.entry = {.count = 1, .reusable = true}}, SHIFT(39),
+  [1152] = {.entry = {.count = 1, .reusable = true}}, SHIFT(85),
+  [1154] = {.entry = {.count = 1, .reusable = true}}, SHIFT(336),
+  [1156] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
+  [1158] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_finally_statement, 4, 100, 0),
+  [1160] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, 0, 19),
+  [1162] = {.entry = {.count = 1, .reusable = true}}, SHIFT(147),
+  [1164] = {.entry = {.count = 1, .reusable = true}}, SHIFT(96),
+  [1166] = {.entry = {.count = 1, .reusable = false}}, SHIFT(82),
+  [1168] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_inline_else_statement, 3, 100, 0),
+  [1170] = {.entry = {.count = 1, .reusable = true}}, SHIFT(427),
+  [1172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, 0, 8),
+  [1174] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in, 2, 0, 0),
+  [1176] = {.entry = {.count = 1, .reusable = true}}, SHIFT(163),
+  [1178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(164),
+  [1180] = {.entry = {.count = 1, .reusable = true}}, SHIFT(165),
+  [1182] = {.entry = {.count = 1, .reusable = true}}, SHIFT(57),
+  [1184] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 9, 0, 20),
+  [1186] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 6, 0, 12),
+  [1188] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [1190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_enumerate, 2, 0, 0),
+  [1192] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_zip, 2, 0, 0),
+  [1194] = {.entry = {.count = 1, .reusable = true}}, SHIFT(68),
+  [1196] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elseif_statement, 6, 100, 21),
+  [1198] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__for_in_range, 7, 0, 0),
+  [1200] = {.entry = {.count = 1, .reusable = true}}, SHIFT(171),
+  [1202] = {.entry = {.count = 1, .reusable = true}}, SHIFT(172),
+  [1204] = {.entry = {.count = 1, .reusable = true}}, SHIFT(374),
+  [1206] = {.entry = {.count = 1, .reusable = true}}, SHIFT(252),
+  [1208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, 200, 0),
+  [1210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 5, 0, 6),
+  [1212] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 5, 0, 4),
+  [1214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(105),
+  [1216] = {.entry = {.count = 1, .reusable = true}}, SHIFT(176),
+  [1218] = {.entry = {.count = 1, .reusable = true}}, SHIFT(111),
+  [1220] = {.entry = {.count = 1, .reusable = true}}, SHIFT(26),
+  [1222] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_test_case_setting, 6, 0, 6),
+  [1224] = {.entry = {.count = 1, .reusable = false}}, SHIFT(206),
+  [1226] = {.entry = {.count = 1, .reusable = false}}, SHIFT(303),
+  [1228] = {.entry = {.count = 1, .reusable = false}}, SHIFT(304),
+  [1230] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_setting, 4, 0, 4),
+  [1232] = {.entry = {.count = 1, .reusable = false}}, SHIFT(55),
+  [1234] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+  [1236] = {.entry = {.count = 1, .reusable = false}}, SHIFT(80),
+  [1238] = {.entry = {.count = 1, .reusable = false}}, SHIFT(213),
+  [1240] = {.entry = {.count = 1, .reusable = false}}, SHIFT(309),
+  [1242] = {.entry = {.count = 1, .reusable = false}}, SHIFT(310),
+  [1244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(8),
+  [1246] = {.entry = {.count = 1, .reusable = false}}, SHIFT(218),
+  [1248] = {.entry = {.count = 1, .reusable = false}}, SHIFT(314),
+  [1250] = {.entry = {.count = 1, .reusable = false}}, SHIFT(315),
+  [1252] = {.entry = {.count = 1, .reusable = true}}, SHIFT(231),
+  [1254] = {.entry = {.count = 1, .reusable = false}}, SHIFT(222),
+  [1256] = {.entry = {.count = 1, .reusable = true}}, SHIFT(66),
 };
 
 #ifdef __cplusplus

--- a/test/corpus/subscripts.txt
+++ b/test/corpus/subscripts.txt
@@ -1,0 +1,155 @@
+================================================================================
+Integer subscript
+================================================================================
+
+*** Keywords ***
+
+Log First Value Of Variable
+    [Arguments]    ${var}
+    Log    ${var[0]}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (keywords_section
+      (section_header)
+      (keyword_definition
+        (name
+          (name_chunk))
+        (body
+          (keyword_setting
+            (keyword_setting_name)
+            (arguments
+              (argument
+                (scalar_variable
+                  (variable_name)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (scalar_variable
+                    (variable_name)
+                    (variable_key)))))))))))
+
+================================================================================
+String subscript
+================================================================================
+
+*** Keywords ***
+
+Log Foo From Dictionary
+    [Arguments]    ${dict}
+    Log    ${dict["foo"]}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (keywords_section
+      (section_header)
+      (keyword_definition
+        (name
+          (name_chunk))
+        (body
+          (keyword_setting
+            (keyword_setting_name)
+            (arguments
+              (argument
+                (scalar_variable
+                  (variable_name)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (scalar_variable
+                    (variable_name)
+                    (variable_key)))))))))))
+
+================================================================================
+Multiple subscripts
+================================================================================
+
+*** Keywords ***
+
+Log Foo Bar Baz From Dictionary
+    [Arguments]    ${dict}
+    Log    ${dict["foo"]["bar"]["baz"]}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (keywords_section
+      (section_header)
+      (keyword_definition
+        (name
+          (name_chunk))
+        (body
+          (keyword_setting
+            (keyword_setting_name)
+            (arguments
+              (argument
+                (scalar_variable
+                  (variable_name)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (scalar_variable
+                    (variable_name)
+                    (variable_key)
+                    (variable_key)
+                    (variable_key)))))))))))
+
+================================================================================
+Nested subscripts
+================================================================================
+
+*** Keywords ***
+
+Log Foo From Nested Dictionaries
+    [Arguments]    ${dict1}    ${dict2}    ${dict3}
+    Log    ${dict1[${dict2[${dict3["foo"]}]}]}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (section
+    (keywords_section
+      (section_header)
+      (keyword_definition
+        (name
+          (name_chunk))
+        (body
+          (keyword_setting
+            (keyword_setting_name)
+            (arguments
+              (argument
+                (scalar_variable
+                  (variable_name)))
+              (argument
+                (scalar_variable
+                  (variable_name)))
+              (argument
+                (scalar_variable
+                  (variable_name)))))
+          (statement
+            (keyword_invocation
+              (keyword
+                (name_chunk))
+              (arguments
+                (argument
+                  (scalar_variable
+                    (variable_name)
+                    (scalar_variable
+                      (variable_name)
+                      (scalar_variable
+                        (variable_name)
+                        (variable_key)))))))))))))


### PR DESCRIPTION
This change adds preliminary support for scalar variables that can be subscripted with square brackets.

Example use-case, in which `${example}` is a dictionary imported from a python variablefile:
```robotframework
*** Test Cases ***
Log From Dictionary Two Ways
    Log    ${example["key"]}
    Log Dictionary Value    ${example}    "key"

*** Keywords ***
Log Dictionary Value
    [Arguments]    ${dictionary}    ${key}
    Log    ${dictionary[${key}]}
```